### PR TITLE
Improve dark theme and feed visuals

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,7 +14,7 @@ export default function SocialListeningApp() {
   const [activeTab, setActiveTab] = useState("home");
 
   return (
-    <div className="min-h-screen flex bg-gray-100 text-gray-800">
+    <div className="min-h-screen flex bg-neutral-950 text-gray-100">
       {/* Sidebar */}
       <aside className="w-64 bg-white shadow-md p-6 space-y-4">
         <h1 className="text-xl font-bold mb-4">🔍 Social Listening</h1>
@@ -28,7 +28,7 @@ export default function SocialListeningApp() {
         {activeTab === "home" && (
           <section className="max-w-2xl mx-auto">
             <h2 className="text-2xl font-bold mb-4">📡 Menciones recientes</h2>
-            <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-6">
               {[...Array(6)].map((_, i) => (
                 <MentionCard
                   key={i}

--- a/src/components/MentionCard.jsx
+++ b/src/components/MentionCard.jsx
@@ -5,16 +5,16 @@ export default function MentionCard({ source = "twitter", username, timestamp, c
   const Icon = source === "youtube" ? Youtube : Twitter;
   return (
     <Card className="border-muted bg-secondary hover:bg-secondary/70 transition-colors rounded-lg">
-      <CardContent className="p-4 flex gap-3">
-        <div className="w-10 h-10 flex items-center justify-center bg-muted rounded-full shrink-0">
-          <Icon className="text-primary size-5" />
+      <CardContent className="p-6 flex gap-4">
+        <div className="w-12 h-12 flex items-center justify-center bg-muted rounded-full shrink-0">
+          <Icon className="text-primary size-6" />
         </div>
         <div className="flex-1 space-y-1">
           <div className="flex items-center justify-between">
             <span className="font-semibold text-primary">@{username}</span>
             <span className="text-xs text-muted-foreground">{timestamp}</span>
           </div>
-          <p className="text-sm leading-relaxed text-muted-foreground">{content}</p>
+          <p className="text-base leading-relaxed text-muted-foreground">{content}</p>
         </div>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary
- darken the main background
- enlarge gap for feed items
- increase MentionCard spacing and font size

## Testing
- `npm run build` *(fails: esbuild platform mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_687050d4fbe4832b8ae99f87a395664b