### PR TITLE
Refactor search placement and add profile icon

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,15 +7,20 @@ import MentionCard from "@/components/MentionCard";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 import RightSidebar from "@/components/RightSidebar";
+import { Search, CircleUser } from "lucide-react";
 
 export default function SocialListeningApp() {
   // State for date range filters in dashboard
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
   const [activeTab, setActiveTab] = useState("home");
+  const [search, setSearch] = useState("");
 
   return (
-    <div className="min-h-screen flex bg-neutral-950 text-gray-100">
+    <div className="min-h-screen flex bg-neutral-950 text-gray-100 relative">
+      <button className="absolute top-4 right-4 text-muted-foreground hover:text-foreground">
+        <CircleUser className="size-7" />
+      </button>
       {/* Sidebar */}
       <aside className="w-64 bg-secondary shadow-md p-6 space-y-4">
         <h1 className="text-xl font-bold mb-4">🔍 Social Listening</h1>
@@ -28,6 +33,15 @@ export default function SocialListeningApp() {
       <main className="flex-1 p-8 overflow-y-auto">
         {activeTab === "home" && (
           <section className="max-w-2xl mx-auto">
+            <div className="mb-6 flex justify-center relative">
+              <Search className="absolute left-3 top-2.5 size-4 text-muted-foreground" />
+              <Input
+                placeholder="Buscar..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="pl-9 w-full max-w-md"
+              />
+            </div>
             <h2 className="text-2xl font-bold mb-4">📡 Menciones recientes</h2>
             <div className="flex flex-col gap-6">
               {[...Array(6)].map((_, i) => (

--- a/src/components/RightSidebar.jsx
+++ b/src/components/RightSidebar.jsx
@@ -1,13 +1,11 @@
 import { useRef, useState } from "react";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Search, FilterX } from "lucide-react";
+import { FilterX } from "lucide-react";
 
 export default function RightSidebar() {
   const [range, setRange] = useState("");
-  const [search, setSearch] = useState("");
   const sidebarRef = useRef(null);
 
   const handleClearFilters = () => {
@@ -25,16 +23,6 @@ export default function RightSidebar() {
       ref={sidebarRef}
       className="w-64 bg-secondary shadow-md p-6 space-y-6 flex flex-col h-full"
     >
-      <div className="relative">
-        <Search className="absolute left-3 top-2.5 size-4 text-muted-foreground" />
-        <Input
-          placeholder="Buscar..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="pl-9"
-        />
-      </div>
-
       <div>
         <p className="font-semibold mb-2">Rango de tiempo</p>
         <Select value={range} onValueChange={setRange}>


### PR DESCRIPTION
## Summary
- center the search bar above the feed and remove it from the sidebar
- add a user icon in the top right corner for profile/settings access

## Testing
- `npm run build` *(fails: esbuild platform mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_687079539c18832bb62703ac5e05d1cc