### PR TITLE
Armonizar altura y bordes de sidebar derecho

### DIFF
--- a/src/components/RightSidebar.jsx
+++ b/src/components/RightSidebar.jsx
@@ -21,7 +21,7 @@ export default function RightSidebar() {
   return (
     <aside
       ref={sidebarRef}
-      className="w-64 bg-secondary shadow-md p-6 space-y-6 flex flex-col h-full mt-6"
+      className="w-64 bg-secondary shadow-md p-6 space-y-6 flex flex-col mt-8 rounded-lg self-start"
     >
       <div>
         <p className="font-semibold mb-2">Rango de tiempo</p>


### PR DESCRIPTION
## Summary
- baja la barra lateral derecha para que comience a la altura del feed
- agrega esquinas redondeadas al contenedor del sidebar

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870945d3bc0832b85e9664cf83c9794