### PR TITLE
Add platform icons to feed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react": "^18.2.0",
         "react-day-picker": "^9.8.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^5.5.0",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -2843,6 +2844,15 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react": "^18.2.0",
     "react-day-picker": "^9.8.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^5.5.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/src/components/MentionCard.jsx
+++ b/src/components/MentionCard.jsx
@@ -1,8 +1,13 @@
 import { Card, CardContent } from "@/components/ui/card";
-import { Twitter, Youtube } from "lucide-react";
+import { FaTwitter, FaYoutube, FaReddit } from "react-icons/fa";
 
 export default function MentionCard({ source = "twitter", username, timestamp, content }) {
-  const Icon = source === "youtube" ? Youtube : Twitter;
+  const icons = {
+    twitter: FaTwitter,
+    youtube: FaYoutube,
+    reddit: FaReddit,
+  };
+  const Icon = icons[source?.toLowerCase?.()] || FaTwitter;
   return (
     <Card className="border-muted bg-secondary hover:bg-secondary/70 transition-colors rounded-lg">
       <CardContent className="p-6 flex gap-4">


### PR DESCRIPTION
## Summary
- add `react-icons` dependency
- show correct platform icon in `MentionCard`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68720777782c832bb9f58d446d1b889b