### PR TITLE
Load mentions incrementally with expandable cards

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,7 +30,7 @@ export default function SocialListeningApp() {
       m.source.toLowerCase().includes(search.toLowerCase())
   );
 
-  const fetchMentions = async (from = 0, to = 9) => {
+  const fetchMentions = async (from = 0, to = 4) => {
     const { data, error } = await supabase
       .from("total_mentions_vw")
       .select("*")
@@ -49,7 +49,7 @@ export default function SocialListeningApp() {
 
   const loadMore = async () => {
     setLoadingMore(true);
-    await fetchMentions(mentions.length, mentions.length + 9);
+    await fetchMentions(mentions.length, mentions.length + 4);
     setLoadingMore(false);
   };
 
@@ -117,6 +117,7 @@ export default function SocialListeningApp() {
                     timestamp={new Date(m.created_at).toLocaleString()}
                     content={m.mention}
                     keyword={m.keyword}
+                    url={m.url}
                   />
                 ))
               ) : (

--- a/src/components/MentionCard.jsx
+++ b/src/components/MentionCard.jsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { FaTwitter, FaYoutube, FaReddit } from "react-icons/fa";
 
@@ -7,6 +8,7 @@ export default function MentionCard({
   timestamp,
   content,
   keyword,
+  url,
 }) {
   const icons = {
     twitter: FaTwitter,
@@ -14,8 +16,13 @@ export default function MentionCard({
     reddit: FaReddit,
   };
   const Icon = icons[source?.toLowerCase?.()] || FaTwitter;
+  const [expanded, setExpanded] = useState(false);
+
   return (
-    <Card className="border-muted bg-secondary hover:bg-secondary/70 transition-colors rounded-lg">
+    <Card
+      onClick={() => setExpanded((e) => !e)}
+      className="border-muted bg-secondary hover:bg-secondary/70 transition-colors rounded-lg cursor-pointer"
+    >
       <CardContent className="p-6 flex gap-4">
         <div className="w-12 h-12 flex items-center justify-center bg-muted rounded-full shrink-0">
           <Icon className="text-primary size-6" />
@@ -30,6 +37,22 @@ export default function MentionCard({
             <span className="inline-block text-xs mt-2 bg-muted text-muted-foreground px-2 py-0.5 rounded">
               {keyword}
             </span>
+          )}
+          {expanded && (
+            <div className="mt-2 space-y-1 text-sm">
+              {url && (
+                <a
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline block"
+                >
+                  {url}
+                </a>
+              )}
+              <p className="text-muted-foreground">Resumen de la mención (dummy).</p>
+              <p className="text-muted-foreground">Análisis de sentimiento (dummy).</p>
+            </div>
           )}
         </div>
       </CardContent>


### PR DESCRIPTION
## Summary
- show only 5 mentions at a time
- load 5 more mentions with *Ver más*
- allow mention cards to expand on click showing URL and dummy details

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68728c0d4574832b8148a93b78c4548a