### PR TITLE
Implement favorites section in feed

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -112,6 +112,7 @@ export default function SocialListeningApp() {
                 filteredMentions.map((m, i) => (
                   <MentionCard
                     key={`${m.created_at}-${i}`}
+                    mention={m}
                     source={m.platform}
                     username={m.source}
                     timestamp={new Date(m.created_at).toLocaleString()}

--- a/src/components/MentionCard.jsx
+++ b/src/components/MentionCard.jsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
-import { FaTwitter, FaYoutube, FaReddit } from "react-icons/fa";
+import { FaTwitter, FaYoutube, FaReddit, FaHeart, FaRegHeart } from "react-icons/fa";
+import { useFavorites } from "@/context/FavoritesContext";
 
 export default function MentionCard({
+  mention,
   source = "twitter",
   username,
   timestamp,
@@ -17,12 +19,25 @@ export default function MentionCard({
   };
   const Icon = icons[source?.toLowerCase?.()] || FaTwitter;
   const [expanded, setExpanded] = useState(false);
+  const { toggleFavorite, isFavorite } = useFavorites();
+  const favorite = isFavorite(mention);
+
+  const handleFavClick = (e) => {
+    e.stopPropagation();
+    toggleFavorite(mention);
+  };
 
   return (
     <Card
       onClick={() => setExpanded((e) => !e)}
-      className="border-muted bg-secondary hover:bg-secondary/70 transition-colors rounded-lg cursor-pointer"
+      className="relative border-muted bg-secondary hover:bg-secondary/70 transition-colors rounded-lg cursor-pointer"
     >
+      <button
+        onClick={handleFavClick}
+        className="absolute top-2 right-2 text-primary hover:text-primary/80"
+      >
+        {favorite ? <FaHeart /> : <FaRegHeart />}
+      </button>
       <CardContent className="p-6 flex gap-4">
         <div className="w-12 h-12 flex items-center justify-center bg-muted rounded-full shrink-0">
           <Icon className="text-primary size-6" />

--- a/src/components/RightSidebar.jsx
+++ b/src/components/RightSidebar.jsx
@@ -1,12 +1,15 @@
 import { useRef, useState } from "react";
+import { useFavorites } from "@/context/FavoritesContext";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
 import { FilterX } from "lucide-react";
+import { FaHeart } from "react-icons/fa";
 
 export default function RightSidebar() {
   const [range, setRange] = useState("");
   const sidebarRef = useRef(null);
+  const { favorites, toggleFavorite } = useFavorites();
 
   const handleClearFilters = () => {
     setRange("");
@@ -23,6 +26,23 @@ export default function RightSidebar() {
       ref={sidebarRef}
       className="w-64 bg-secondary shadow-md p-6 space-y-6 flex flex-col mt-8 rounded-lg self-start"
     >
+      <div>
+        <p className="font-semibold mb-2">Favoritos</p>
+        {favorites.length ? (
+          <div className="space-y-2 max-h-40 overflow-y-auto">
+            {favorites.map((f) => (
+              <div key={f.created_at} className="text-sm flex items-start gap-2">
+                <span className="flex-1 line-clamp-2">{f.mention}</span>
+                <button onClick={() => toggleFavorite(f)} className="text-primary hover:text-primary/80">
+                  <FaHeart />
+                </button>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-muted-foreground text-sm">No hay favoritos</p>
+        )}
+      </div>
       <div>
         <p className="font-semibold mb-2">Rango de tiempo</p>
         <Select value={range} onValueChange={setRange}>

--- a/src/context/FavoritesContext.jsx
+++ b/src/context/FavoritesContext.jsx
@@ -1,0 +1,34 @@
+import { createContext, useContext, useState } from "react";
+
+const FavoritesContext = createContext(null);
+
+export function FavoritesProvider({ children }) {
+  const [favorites, setFavorites] = useState([]);
+
+  const toggleFavorite = (mention) => {
+    setFavorites((prev) => {
+      const exists = prev.find((m) => m.created_at === mention.created_at);
+      if (exists) {
+        return prev.filter((m) => m.created_at !== mention.created_at);
+      }
+      return [...prev, mention];
+    });
+  };
+
+  const isFavorite = (mention) =>
+    favorites.some((m) => m.created_at === mention.created_at);
+
+  return (
+    <FavoritesContext.Provider value={{ favorites, toggleFavorite, isFavorite }}>
+      {children}
+    </FavoritesContext.Provider>
+  );
+}
+
+export function useFavorites() {
+  const context = useContext(FavoritesContext);
+  if (!context) {
+    throw new Error("useFavorites must be used within FavoritesProvider");
+  }
+  return context;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,8 +2,12 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import './index.css'
+import { FavoritesProvider } from './context/FavoritesContext'
+
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <FavoritesProvider>
+      <App />
+    </FavoritesProvider>
   </React.StrictMode>
 )


### PR DESCRIPTION
## Summary
- add `FavoritesProvider` and `useFavorites` hook
- allow mentions to be toggled as favorites
- display favorite mentions in the right sidebar
- wrap app with favorites context

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68729639de8c832b927e776d90e8cb5b