### PR TITLE
Implement relative timestamps and UI tweaks

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,8 @@ import {
   Heart,
 } from "lucide-react";
 import { useFavorites } from "@/context/FavoritesContext";
+import { formatDistanceToNow } from "date-fns";
+import { es } from "date-fns/locale";
 
 export default function SocialListeningApp() {
   // State for date range filters in dashboard
@@ -131,7 +133,7 @@ export default function SocialListeningApp() {
       {/* Main Content */}
       <main className="flex-1 p-8 overflow-y-auto">
         {activeTab === "home" && (
-          <section className="max-w-2xl mx-auto">
+          <section className="max-w-5xl mx-auto">
             <div className="mb-6 flex justify-center relative">
               <Search className="absolute left-3 top-2.5 size-4 text-muted-foreground" />
               <Input
@@ -142,34 +144,40 @@ export default function SocialListeningApp() {
               />
             </div>
             <h2 className="text-2xl font-bold mb-4">📡 Menciones recientes</h2>
-            <div className="flex flex-col gap-6">
-              {filteredMentions.length ? (
-                filteredMentions.map((m, i) => (
-                  <MentionCard
-                    key={`${m.created_at}-${i}`}
-                    mention={m}
-                    source={m.platform}
-                    username={m.source}
-                    timestamp={new Date(m.created_at).toLocaleString()}
-                    content={m.mention}
-                    keyword={m.keyword}
-                    url={m.url}
-                  />
-                ))
-              ) : (
-                <p className="text-center text-muted-foreground">
-                  No se encontraron menciones
-                </p>
-              )}
+            <div className="flex items-start gap-8">
+              <div className="flex-1 flex flex-col gap-6">
+                {filteredMentions.length ? (
+                  filteredMentions.map((m, i) => (
+                    <MentionCard
+                      key={`${m.created_at}-${i}`}
+                      mention={m}
+                      source={m.platform}
+                      username={m.source}
+                      timestamp={formatDistanceToNow(new Date(m.created_at), {
+                        addSuffix: true,
+                        locale: es,
+                      })}
+                      content={m.mention}
+                      keyword={m.keyword}
+                      url={m.url}
+                    />
+                  ))
+                ) : (
+                  <p className="text-center text-muted-foreground">
+                    No se encontraron menciones
+                  </p>
+                )}
+                <Button
+                  onClick={loadMore}
+                  disabled={loadingMore}
+                  className="mx-auto mt-6 block"
+                  variant="outline"
+                >
+                  {loadingMore ? "Cargando..." : "Ver más"}
+                </Button>
+              </div>
+              <RightSidebar className="mt-0" />
             </div>
-            <Button
-              onClick={loadMore}
-              disabled={loadingMore}
-              className="mx-auto mt-6 block"
-              variant="outline"
-            >
-              {loadingMore ? "Cargando..." : "Ver más"}
-            </Button>
           </section>
         )}
 
@@ -184,7 +192,10 @@ export default function SocialListeningApp() {
                     mention={m}
                     source={m.platform}
                     username={m.source}
-                    timestamp={new Date(m.created_at).toLocaleString()}
+                    timestamp={formatDistanceToNow(new Date(m.created_at), {
+                      addSuffix: true,
+                      locale: es,
+                    })}
                     content={m.mention}
                     keyword={m.keyword}
                     url={m.url}
@@ -269,8 +280,6 @@ export default function SocialListeningApp() {
           </section>
         )}
       </main>
-      {/* Right Sidebar */}
-      <RightSidebar />
     </div>
   );
 }

--- a/src/components/MentionCard.jsx
+++ b/src/components/MentionCard.jsx
@@ -48,11 +48,6 @@ export default function MentionCard({
             <span className="text-xs text-muted-foreground">{timestamp}</span>
           </div>
           <p className="text-base leading-relaxed text-muted-foreground">{content}</p>
-          {keyword && (
-            <span className="inline-block text-xs mt-2 bg-muted text-muted-foreground px-2 py-0.5 rounded">
-              {keyword}
-            </span>
-          )}
           {expanded && (
             <div className="mt-2 space-y-1 text-sm">
               {url && (
@@ -64,6 +59,11 @@ export default function MentionCard({
                 >
                   {url}
                 </a>
+              )}
+              {keyword && (
+                <span className="inline-block text-xs bg-primary text-primary-foreground px-2 py-0.5 rounded">
+                  {keyword}
+                </span>
               )}
               <p className="text-muted-foreground">Resumen de la mención (dummy).</p>
               <p className="text-muted-foreground">Análisis de sentimiento (dummy).</p>

--- a/src/components/RightSidebar.jsx
+++ b/src/components/RightSidebar.jsx
@@ -5,8 +5,9 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
 import { FilterX } from "lucide-react";
 import { FaHeart } from "react-icons/fa";
+import { cn } from "@/lib/utils";
 
-export default function RightSidebar() {
+export default function RightSidebar({ className = "" }) {
   const [range, setRange] = useState("");
   const sidebarRef = useRef(null);
   const { favorites, toggleFavorite } = useFavorites();
@@ -24,7 +25,10 @@ export default function RightSidebar() {
   return (
     <aside
       ref={sidebarRef}
-      className="w-64 bg-secondary shadow-md p-6 space-y-6 flex flex-col mt-8 rounded-lg self-start"
+      className={cn(
+        "w-64 bg-secondary shadow-md p-6 space-y-6 flex flex-col rounded-lg self-start",
+        className
+      )}
     >
       <div>
         <p className="font-semibold mb-2">Favoritos</p>
@@ -102,3 +106,4 @@ export default function RightSidebar() {
     </aside>
   );
 }
+


### PR DESCRIPTION
## Summary
- show relative timestamps in feed using **date-fns**
- hide keyword tag until a mention is expanded
- refactor layout so RightSidebar lines up with first mention
- expose `className` prop for `RightSidebar`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68742f7a4020832b8b382a7d9f96a736