### PR TITLE
Adjust RightSidebar layout and remove favorites

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -131,9 +131,9 @@ export default function SocialListeningApp() {
       </aside>
 
       {/* Main Content */}
-      <main className="flex-1 p-8 overflow-y-auto">
+      <main className="flex-1 p-8 pr-0 overflow-y-auto">
         {activeTab === "home" && (
-          <section className="max-w-5xl mx-auto">
+          <section>
             <div className="mb-6 flex justify-center relative">
               <Search className="absolute left-3 top-2.5 size-4 text-muted-foreground" />
               <Input

--- a/src/components/RightSidebar.jsx
+++ b/src/components/RightSidebar.jsx
@@ -1,16 +1,13 @@
 import { useRef, useState } from "react";
-import { useFavorites } from "@/context/FavoritesContext";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
 import { FilterX } from "lucide-react";
-import { FaHeart } from "react-icons/fa";
 import { cn } from "@/lib/utils";
 
 export default function RightSidebar({ className = "" }) {
   const [range, setRange] = useState("");
   const sidebarRef = useRef(null);
-  const { favorites, toggleFavorite } = useFavorites();
 
   const handleClearFilters = () => {
     setRange("");
@@ -30,23 +27,6 @@ export default function RightSidebar({ className = "" }) {
         className
       )}
     >
-      <div>
-        <p className="font-semibold mb-2">Favoritos</p>
-        {favorites.length ? (
-          <div className="space-y-2 max-h-40 overflow-y-auto">
-            {favorites.map((f) => (
-              <div key={f.created_at} className="text-sm flex items-start gap-2">
-                <span className="flex-1 line-clamp-2">{f.mention}</span>
-                <button onClick={() => toggleFavorite(f)} className="text-primary hover:text-primary/80">
-                  <FaHeart />
-                </button>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <p className="text-muted-foreground text-sm">No hay favoritos</p>
-        )}
-      </div>
       <div>
         <p className="font-semibold mb-2">Rango de tiempo</p>
         <Select value={range} onValueChange={setRange}>


### PR DESCRIPTION
## Summary
- align RightSidebar with the screen edge by removing right padding from the main container
- let the home section span the full width so the sidebar sits flush to the right
- drop the favorites list from the right sidebar
- keep mentions expandable with a clickable URL

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687432f1b2f8832b9953f3d0849f8476