### PR TITLE
Fix duplicate handling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -69,11 +69,17 @@ export default function SocialListeningApp() {
       .select("*")
       .order("created_at", { ascending: false })
       .range(from, to);
+
     if (error) {
       console.error("Error fetching mentions", error);
-    } else {
-      setMentions((prev) => [...prev, ...(data || [])]);
+      return;
     }
+
+    setMentions((prev) => {
+      const existing = new Set(prev.map((m) => m.url));
+      const newMentions = (data || []).filter((m) => !existing.has(m.url));
+      return [...prev, ...newMentions];
+    });
   };
 
   useEffect(() => {
@@ -184,9 +190,9 @@ export default function SocialListeningApp() {
             <div className="flex items-start gap-8">
               <div className="flex-1 flex flex-col gap-6 max-w-3xl mx-auto">
                 {sortedMentions.length ? (
-                  sortedMentions.map((m, i) => (
+                  sortedMentions.map((m) => (
                     <MentionCard
-                      key={`${m.created_at}-${i}`}
+                      key={m.url}
                       mention={m}
                       source={m.platform}
                       username={m.source}
@@ -232,9 +238,9 @@ export default function SocialListeningApp() {
             <h2 className="text-2xl font-bold mb-4">❤️ Favoritos</h2>
             <div className="flex flex-col gap-6">
               {favorites.length ? (
-                favorites.map((m, i) => (
+                favorites.map((m) => (
                   <MentionCard
-                    key={`${m.created_at}-${i}`}
+                    key={m.url}
                     mention={m}
                     source={m.platform}
                     username={m.source}

--- a/src/context/FavoritesContext.jsx
+++ b/src/context/FavoritesContext.jsx
@@ -7,16 +7,15 @@ export function FavoritesProvider({ children }) {
 
   const toggleFavorite = (mention) => {
     setFavorites((prev) => {
-      const exists = prev.find((m) => m.created_at === mention.created_at);
+      const exists = prev.find((m) => m.url === mention.url);
       if (exists) {
-        return prev.filter((m) => m.created_at !== mention.created_at);
+        return prev.filter((m) => m.url !== mention.url);
       }
       return [...prev, mention];
     });
   };
 
-  const isFavorite = (mention) =>
-    favorites.some((m) => m.created_at === mention.created_at);
+  const isFavorite = (mention) => favorites.some((m) => m.url === mention.url);
 
   return (
     <FavoritesContext.Provider value={{ favorites, toggleFavorite, isFavorite }}>


### PR DESCRIPTION
## Summary
- deduplicate fetched mentions using the URL
- track favourites by URL instead of creation timestamp
- use the URL as React key when rendering MentionCards

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6874676c4060832b8d3f0cbd114d7008