### PR TITLE
Use URL as mention id

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -73,8 +73,8 @@ export default function SocialListeningApp() {
       console.error("Error fetching mentions", error);
     } else {
       setMentions((prev) => {
-        const existing = new Set(prev.map((m) => m.created_at));
-        const unique = (data || []).filter((m) => !existing.has(m.created_at));
+        const existing = new Set(prev.map((m) => m.url));
+        const unique = (data || []).filter((m) => !existing.has(m.url));
         return [...prev, ...unique];
       });
     }
@@ -190,9 +190,9 @@ export default function SocialListeningApp() {
                 <div className="flex flex-col gap-6">
                   {sortedMentions.length ? (
                     sortedMentions.map((m, i) => (
-                      <MentionCard
-                        key={`${m.created_at}-${i}`}
-                        mention={m}
+                    <MentionCard
+                      key={m.url}
+                      mention={m}
                         source={m.platform}
                         username={m.source}
                         timestamp={formatDistanceToNow(new Date(m.created_at), {
@@ -240,7 +240,7 @@ export default function SocialListeningApp() {
               {favorites.length ? (
                 favorites.map((m, i) => (
                   <MentionCard
-                    key={`${m.created_at}-${i}`}
+                    key={m.url}
                     mention={m}
                     source={m.platform}
                     username={m.source}

--- a/src/context/FavoritesContext.jsx
+++ b/src/context/FavoritesContext.jsx
@@ -7,16 +7,16 @@ export function FavoritesProvider({ children }) {
 
   const toggleFavorite = (mention) => {
     setFavorites((prev) => {
-      const exists = prev.find((m) => m.created_at === mention.created_at);
+      const exists = prev.find((m) => m.url === mention.url);
       if (exists) {
-        return prev.filter((m) => m.created_at !== mention.created_at);
+        return prev.filter((m) => m.url !== mention.url);
       }
       return [...prev, mention];
     });
   };
 
   const isFavorite = (mention) =>
-    favorites.some((m) => m.created_at === mention.created_at);
+    favorites.some((m) => m.url === mention.url);
 
   return (
     <FavoritesContext.Provider value={{ favorites, toggleFavorite, isFavorite }}>


### PR DESCRIPTION
## Summary
- de-duplicate mentions by URL instead of timestamp
- track favorites by URL
- keep React `key` props consistent with URL-based IDs

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6874693f0b54832bb2063ba9e024530c