### PR TITLE
Add login page and integrate auth

### DIFF
--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -1,0 +1,52 @@
+import { useState } from "react";
+import { supabase } from "@/lib/supabaseClient";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+export default function Login() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const handleLogin = async (e) => {
+    e.preventDefault();
+    try {
+      const { error } = await supabase.auth.signInWithPassword({
+        email,
+        password,
+      });
+      if (error) {
+        console.error("Error signing in", error);
+      }
+    } catch (err) {
+      console.error("Error signing in", err);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-neutral-950 text-gray-100">
+      <form onSubmit={handleLogin} className="bg-secondary p-8 rounded-lg space-y-4 shadow-md w-80">
+        <h1 className="text-2xl font-bold text-center">Iniciar sesión</h1>
+        <Input
+          placeholder="Usuario"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <Input
+          placeholder="Contraseña"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <Button type="submit" className="w-full">
+          Iniciar sesión
+        </Button>
+        <p className="text-sm text-center text-muted-foreground">
+          ¿No tienes cuenta?{' '}
+          <a href="#" className="text-primary hover:underline">
+            Regístrate
+          </a>
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,13 +1,41 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App'
-import './index.css'
-import { FavoritesProvider } from './context/FavoritesContext'
+import React, { useEffect, useState } from 'react';
+import ReactDOM from 'react-dom/client';
+import SocialListeningApp from './App';
+import Login from './Login';
+import './index.css';
+import { FavoritesProvider } from './context/FavoritesContext';
+import { supabase } from './lib/supabaseClient';
+
+function Root() {
+  const [session, setSession] = useState(null);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setSession(session);
+    });
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session);
+    });
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  if (!session) {
+    return <Login />;
+  }
+
+  return (
+    <FavoritesProvider>
+      <SocialListeningApp />
+    </FavoritesProvider>
+  );
+}
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <FavoritesProvider>
-      <App />
-    </FavoritesProvider>
+    <Root />
   </React.StrictMode>
-)
+);


### PR DESCRIPTION
## Summary
- implement login page with email and password inputs
- display login screen when Supabase session is absent
- navigate to main app after login and back to login after logout

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6875714ac35c832b8d4eb9edef4b4765