### PR TITLE
Add simple routing and session state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-day-picker": "^9.8.0",
         "react-dom": "^18.2.0",
         "react-icons": "^5.5.0",
+        "react-router-dom": "^6.30.1",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -1466,6 +1467,15 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.19",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.19.tgz",
@@ -2910,6 +2920,38 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-style-singleton": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-day-picker": "^9.8.0",
     "react-dom": "^18.2.0",
     "react-icons": "^5.5.0",
+    "react-router-dom": "^6.30.1",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent } from "@/components/ui/card";
@@ -27,7 +28,7 @@ import { formatDistanceToNow } from "date-fns";
 import { es } from "date-fns/locale";
 
 
-export default function SocialListeningApp() {
+export default function SocialListeningApp({ onLogout }) {
   // State for date range filters in dashboard
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
@@ -38,6 +39,7 @@ export default function SocialListeningApp() {
   const [rangeFilter, setRangeFilter] = useState("");
   const [sourcesFilter, setSourcesFilter] = useState([]);
   const [order, setOrder] = useState("recent");
+  const navigate = useNavigate();
   const { favorites } = useFavorites();
   const filteredMentions = mentions.filter((m) => {
     const matchesSearch =
@@ -89,12 +91,9 @@ export default function SocialListeningApp() {
     fetchMentions();
   }, []);
 
-  const handleLogout = async () => {
-    try {
-      await supabase.auth.signOut();
-    } catch (error) {
-      console.error("Error signing out", error);
-    }
+  const handleLogout = () => {
+    if (onLogout) onLogout();
+    navigate("/login");
   };
 
   const toggleSourceFilter = (id) => {

--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -1,24 +1,16 @@
 import { useState } from "react";
-import { supabase } from "@/lib/supabaseClient";
+import { useNavigate } from "react-router-dom";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 
-export default function Login() {
+export default function Login({ onLogin }) {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const navigate = useNavigate();
   const handleLogin = async (e) => {
     e.preventDefault();
-    try {
-      const { error } = await supabase.auth.signInWithPassword({
-        email,
-        password,
-      });
-      if (error) {
-        console.error("Error signing in", error);
-      }
-    } catch (err) {
-      console.error("Error signing in", err);
-    }
+    if (onLogin) onLogin();
+    navigate("/home");
   };
 
   return (

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,35 +1,38 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import ReactDOM from 'react-dom/client';
 import SocialListeningApp from './App';
 import Login from './Login';
 import './index.css';
 import { FavoritesProvider } from './context/FavoritesContext';
-import { supabase } from './lib/supabaseClient';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 
 function Root() {
-  const [session, setSession] = useState(null);
-
-  useEffect(() => {
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      setSession(session);
-    });
-    const {
-      data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
-      setSession(session);
-    });
-    return () => {
-      subscription.unsubscribe();
-    };
-  }, []);
-
-  if (!session) {
-    return <Login />;
-  }
+  const [loggedIn, setLoggedIn] = useState(false);
 
   return (
     <FavoritesProvider>
-      <SocialListeningApp />
+      <BrowserRouter>
+        <Routes>
+          <Route
+            path="/login"
+            element={<Login onLogin={() => setLoggedIn(true)} />}
+          />
+          <Route
+            path="/home"
+            element={
+              loggedIn ? (
+                <SocialListeningApp onLogout={() => setLoggedIn(false)} />
+              ) : (
+                <Navigate to="/login" replace />
+              )
+            }
+          />
+          <Route
+            path="*"
+            element={<Navigate to={loggedIn ? "/home" : "/login"} replace />}
+          />
+        </Routes>
+      </BrowserRouter>
     </FavoritesProvider>
   );
 }


### PR DESCRIPTION
## Summary
- add `react-router-dom` and wire up simple routes
- simulate login/logout navigation
- integrate Logout button with new session state

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68757995da84832bbc129b3aa6e3b6be