### PR TITLE
Remove duplicate keyword tag

### DIFF
--- a/src/components/MentionCard.jsx
+++ b/src/components/MentionCard.jsx
@@ -45,7 +45,7 @@ export default function MentionCard({
         </div>
         <div className="flex-1 space-y-1">
           {keyword && (
-            <span className="inline-block text-xs bg-primary text-primary-foreground px-2 py-0.5 rounded">
+            <span className="inline-block text-xs bg-muted/50 text-muted-foreground px-2 py-0.5 rounded">
               {keyword}
             </span>
           )}
@@ -53,11 +53,6 @@ export default function MentionCard({
             <span className="font-semibold text-primary">@{username}</span>
             <span className="text-xs text-muted-foreground">{timestamp}</span>
           </div>
-          {keyword && (
-            <span className="inline-block text-xs bg-primary text-primary-foreground px-2 py-0.5 rounded">
-              {keyword}
-            </span>
-          )}
           <p className="text-base leading-relaxed text-muted-foreground">{content}</p>
           {expanded && (
             <div className="mt-2 text-sm">


### PR DESCRIPTION
## Summary
- show the `keyword` tag only once at the top of each mention
- style keyword tag in a subtle grey

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6875d10936a8832bb53fc56b02f44222