### PR TITLE
Agregar opción 'Más populares' y ajustar tag de keyword

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -181,6 +181,7 @@ export default function SocialListeningApp({ onLogout }) {
                   <TabsList>
                     <TabsTrigger value="recent">Más recientes</TabsTrigger>
                     <TabsTrigger value="relevant">Más relevantes</TabsTrigger>
+                    <TabsTrigger value="popular">Más populares</TabsTrigger>
                   </TabsList>
                 </Tabs>
               </div>

--- a/src/components/MentionCard.jsx
+++ b/src/components/MentionCard.jsx
@@ -45,7 +45,7 @@ export default function MentionCard({
         </div>
         <div className="flex-1 space-y-1">
           {keyword && (
-            <span className="inline-block text-xs bg-muted/50 text-muted-foreground px-2 py-0.5 rounded">
+            <span className="inline-block text-xs bg-white/20 text-muted-foreground px-2 py-0.5 rounded">
               {keyword}
             </span>
           )}


### PR DESCRIPTION
## Summary
- add "Más populares" tab in the home filter segmented control
- give keyword tags a subtle white translucent background

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6875d2d2f798832bada97efa1de53c9f