### PR TITLE
Add date filter to home sidebar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,6 +36,8 @@ export default function SocialListeningApp({ onLogout }) {
   const [mentions, setMentions] = useState([]);
   const [menuOpen, setMenuOpen] = useState(false);
   const [rangeFilter, setRangeFilter] = useState("");
+  const [startDateFilter, setStartDateFilter] = useState("");
+  const [endDateFilter, setEndDateFilter] = useState("");
   const [sourcesFilter, setSourcesFilter] = useState([]);
   const [order, setOrder] = useState("recent");
   const [hiddenMentions, setHiddenMentions] = useState([]);
@@ -63,7 +65,19 @@ export default function SocialListeningApp({ onLogout }) {
         return diff <= days;
       })();
 
-    return matchesSearch && matchesSource && matchesRange;
+    const matchesStartDate =
+      !startDateFilter || new Date(m.created_at) >= new Date(startDateFilter);
+
+    const matchesEndDate =
+      !endDateFilter || new Date(m.created_at) <= new Date(endDateFilter);
+
+    return (
+      matchesSearch &&
+      matchesSource &&
+      matchesRange &&
+      matchesStartDate &&
+      matchesEndDate
+    );
   });
 
   const sortedMentions = [...filteredMentions].sort((a, b) => {
@@ -111,6 +125,8 @@ export default function SocialListeningApp({ onLogout }) {
 
   const clearSidebarFilters = () => {
     setRangeFilter("");
+    setStartDateFilter("");
+    setEndDateFilter("");
     setSourcesFilter([]);
     setSearch("");
   };
@@ -225,6 +241,10 @@ export default function SocialListeningApp({ onLogout }) {
                   onSearchChange={setSearch}
                   range={rangeFilter}
                   setRange={setRangeFilter}
+                  startDate={startDateFilter}
+                  setStartDate={setStartDateFilter}
+                  endDate={endDateFilter}
+                  setEndDate={setEndDateFilter}
                   sources={sourcesFilter}
                   toggleSource={toggleSourceFilter}
                   clearFilters={clearSidebarFilters}

--- a/src/components/RightSidebar.jsx
+++ b/src/components/RightSidebar.jsx
@@ -11,6 +11,10 @@ export default function RightSidebar({
   onSearchChange,
   range,
   setRange,
+  startDate,
+  setStartDate,
+  endDate,
+  setEndDate,
   sources,
   toggleSource,
   clearFilters,
@@ -48,6 +52,24 @@ export default function RightSidebar({
             <SelectItem value="30">Últimos 30 días</SelectItem>
           </SelectContent>
         </Select>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Input
+          type="date"
+          value={startDate}
+          onChange={(e) => setStartDate(e.target.value)}
+          placeholder="Desde"
+          className="w-full"
+        />
+        <span>a</span>
+        <Input
+          type="date"
+          value={endDate}
+          onChange={(e) => setEndDate(e.target.value)}
+          placeholder="Hasta"
+          className="w-full"
+        />
       </div>
 
       <div>


### PR DESCRIPTION
## Summary
- add `Desde` and `Hasta` date selectors to the right sidebar
- track new date filter state in `App.jsx`
- filter mentions by the new start and end dates
- reset date filters with the *Limpiar filtros* button

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6878141394b4832bb737c1a45351aa3e