### PR TITLE
Remove date filters from sidebar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,8 +36,6 @@ export default function SocialListeningApp({ onLogout }) {
   const [mentions, setMentions] = useState([]);
   const [menuOpen, setMenuOpen] = useState(false);
   const [rangeFilter, setRangeFilter] = useState("");
-  const [startDateFilter, setStartDateFilter] = useState("");
-  const [endDateFilter, setEndDateFilter] = useState("");
   const [sourcesFilter, setSourcesFilter] = useState([]);
   const [order, setOrder] = useState("recent");
   const [hiddenMentions, setHiddenMentions] = useState([]);
@@ -65,19 +63,7 @@ export default function SocialListeningApp({ onLogout }) {
         return diff <= days;
       })();
 
-    const matchesStartDate =
-      !startDateFilter || new Date(m.created_at) >= new Date(startDateFilter);
-
-    const matchesEndDate =
-      !endDateFilter || new Date(m.created_at) <= new Date(endDateFilter);
-
-    return (
-      matchesSearch &&
-      matchesSource &&
-      matchesRange &&
-      matchesStartDate &&
-      matchesEndDate
-    );
+    return matchesSearch && matchesSource && matchesRange;
   });
 
   const sortedMentions = [...filteredMentions].sort((a, b) => {
@@ -125,8 +111,6 @@ export default function SocialListeningApp({ onLogout }) {
 
   const clearSidebarFilters = () => {
     setRangeFilter("");
-    setStartDateFilter("");
-    setEndDateFilter("");
     setSourcesFilter([]);
     setSearch("");
   };
@@ -241,10 +225,6 @@ export default function SocialListeningApp({ onLogout }) {
                   onSearchChange={setSearch}
                   range={rangeFilter}
                   setRange={setRangeFilter}
-                  startDate={startDateFilter}
-                  setStartDate={setStartDateFilter}
-                  endDate={endDateFilter}
-                  setEndDate={setEndDateFilter}
                   sources={sourcesFilter}
                   toggleSource={toggleSourceFilter}
                   clearFilters={clearSidebarFilters}

--- a/src/components/RightSidebar.jsx
+++ b/src/components/RightSidebar.jsx
@@ -11,10 +11,6 @@ export default function RightSidebar({
   onSearchChange,
   range,
   setRange,
-  startDate,
-  setStartDate,
-  endDate,
-  setEndDate,
   sources,
   toggleSource,
   clearFilters,
@@ -27,7 +23,7 @@ export default function RightSidebar({
   return (
     <aside
       className={cn(
-        "w-64 bg-secondary shadow-md p-6 space-y-6 flex flex-col rounded-lg self-start sticky top-8 h-[calc(100vh-2rem)]",
+        "w-64 bg-secondary shadow-md p-6 space-y-6 flex flex-col items-center rounded-lg self-start sticky top-8 h-[calc(100vh-2rem)]",
         className
       )}
     >
@@ -54,23 +50,6 @@ export default function RightSidebar({
         </Select>
       </div>
 
-      <div className="flex items-center gap-2">
-        <Input
-          type="date"
-          value={startDate}
-          onChange={(e) => setStartDate(e.target.value)}
-          placeholder="Desde"
-          className="w-full"
-        />
-        <span>a</span>
-        <Input
-          type="date"
-          value={endDate}
-          onChange={(e) => setEndDate(e.target.value)}
-          placeholder="Hasta"
-          className="w-full"
-        />
-      </div>
 
       <div>
         <p className="font-semibold mb-2">Fuentes</p>


### PR DESCRIPTION
## Summary
- simplify RightSidebar component by removing start/end date filters
- center remaining sidebar controls
- update App logic to drop removed date filter states and props

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6878166bf9e8832bbec4a1e1511dc94f