### PR TITLE
Fix sidebar alignment and show zero metrics

### DIFF
--- a/src/components/MentionCard.jsx
+++ b/src/components/MentionCard.jsx
@@ -46,31 +46,37 @@ export default function MentionCard({
   };
 
   const renderMetrics = () => {
-    const metrics = [];
-    if (platform === "youtube") {
-      mention.likes && metrics.push({ icon: FaHeart, value: mention.likes });
-      mention.comments && metrics.push({ icon: FaComment, value: mention.comments });
-      mention.views && metrics.push({ icon: FaEye, value: mention.views });
-    }
-    if (platform === "reddit") {
-      mention.likes && metrics.push({ icon: FaArrowUp, value: mention.likes });
-      mention.comments && metrics.push({ icon: FaComment, value: mention.comments });
-    }
-    if (platform === "twitter") {
-      mention.likes && metrics.push({ icon: FaHeart, value: mention.likes });
-      mention.retweets && metrics.push({ icon: FaRetweet, value: mention.retweets });
-      mention.replies && metrics.push({ icon: FaComment, value: mention.replies });
-      mention.quotes && metrics.push({ icon: FaQuoteRight, value: mention.quotes });
-    }
+    const metricMap = {
+      youtube: [
+        { key: "likes", icon: FaHeart },
+        { key: "comments", icon: FaComment },
+        { key: "views", icon: FaEye },
+      ],
+      reddit: [
+        { key: "likes", icon: FaArrowUp },
+        { key: "comments", icon: FaComment },
+      ],
+      twitter: [
+        { key: "likes", icon: FaHeart },
+        { key: "retweets", icon: FaRetweet },
+        { key: "replies", icon: FaComment },
+        { key: "quotes", icon: FaQuoteRight },
+      ],
+    };
+
+    const metrics = metricMap[platform] || [];
+
     if (!metrics.length) return null;
+
     return (
       <div className="flex items-center gap-4 text-sm text-muted-foreground mt-1">
-        {metrics.map((m, idx) => {
+        {metrics.map((m) => {
           const MetricIcon = m.icon;
+          const value = mention[m.key] ?? 0;
           return (
-            <span key={idx} className="flex items-center gap-1">
+            <span key={m.key} className="flex items-center gap-1">
               <MetricIcon className="size-4" />
-              {m.value}
+              {value}
             </span>
           );
         })}

--- a/src/components/RightSidebar.jsx
+++ b/src/components/RightSidebar.jsx
@@ -23,7 +23,7 @@ export default function RightSidebar({
   return (
     <aside
       className={cn(
-        "w-64 bg-secondary shadow-md p-6 space-y-6 flex flex-col items-center rounded-lg self-start sticky top-8 h-[calc(100vh-2rem)]",
+        "w-64 bg-secondary shadow-md p-6 space-y-6 flex flex-col items-end rounded-lg self-start sticky top-8 h-[calc(100vh-2rem)]",
         className
       )}
     >
@@ -92,7 +92,7 @@ export default function RightSidebar({
       <Button
         variant="outline"
         onClick={handleClearFilters}
-        className="mt-auto w-full"
+        className="mt-auto self-center"
       >
         <FilterX className="size-4" />
         Limpiar filtros


### PR DESCRIPTION
## Summary
- align right sidebar content to the right
- keep the Clear Filters button centered
- display metrics icons for mentions even when values are zero

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687947e17e44832b82827097be844306