### PR TITLE
Adjust sidebar alignment and remove relevant tab

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -70,8 +70,23 @@ export default function SocialListeningApp({ onLogout }) {
     if (order === "recent") {
       return new Date(b.created_at) - new Date(a.created_at);
     }
-    // Fallback sorting for "relevant"
-    return new Date(a.created_at) - new Date(b.created_at);
+    if (order === "popular") {
+      const likesDiff = (b.likes ?? 0) - (a.likes ?? 0);
+      if (likesDiff !== 0) return likesDiff;
+
+      const commentsA = a.comments ?? a.replies ?? 0;
+      const commentsB = b.comments ?? b.replies ?? 0;
+      const commentsDiff = commentsB - commentsA;
+      if (commentsDiff !== 0) return commentsDiff;
+
+      const restA =
+        (a.retweets ?? 0) + (a.quotes ?? 0) + (a.views ?? 0);
+      const restB =
+        (b.retweets ?? 0) + (b.quotes ?? 0) + (b.views ?? 0);
+      return restB - restA;
+    }
+
+    return 0;
   });
 
   const visibleMentions = sortedMentions.filter(
@@ -187,7 +202,6 @@ export default function SocialListeningApp({ onLogout }) {
                 <Tabs value={order} onValueChange={setOrder}>
                   <TabsList>
                     <TabsTrigger value="recent">Más recientes</TabsTrigger>
-                    <TabsTrigger value="relevant">Más relevantes</TabsTrigger>
                     <TabsTrigger value="popular">Más populares</TabsTrigger>
                   </TabsList>
                 </Tabs>

--- a/src/components/RightSidebar.jsx
+++ b/src/components/RightSidebar.jsx
@@ -23,7 +23,7 @@ export default function RightSidebar({
   return (
     <aside
       className={cn(
-        "w-64 bg-secondary shadow-md p-6 space-y-6 flex flex-col items-end rounded-lg self-start sticky top-8 h-[calc(100vh-2rem)]",
+        "w-64 bg-secondary shadow-md p-6 space-y-6 flex flex-col items-start rounded-lg self-start sticky top-8 h-[calc(100vh-2rem)]",
         className
       )}
     >


### PR DESCRIPTION
## Summary
- align right sidebar contents to the left
- keep only "Más recientes" and "Más populares" ordering tabs
- sort mentions by likes and comments/replies when "Más populares" is selected

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879a31d9cdc832b8e6d9d22fdbfbc20