### PR TITLE
Add snapshot date to mention card

### DIFF
--- a/src/components/MentionCard.jsx
+++ b/src/components/MentionCard.jsx
@@ -129,6 +129,10 @@ export default function MentionCard({
           {renderMetrics()}
           {expanded && (
             <div className="mt-2 text-sm space-y-1">
+              <p>
+                Métricas al momento de captura (
+                {new Date(mention.created_at).toLocaleString()}):
+              </p>
               {url && (
                 <Button size="sm" asChild onClick={(e) => e.stopPropagation()}>
                   <a href={url} target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
## Summary
- show snapshot date text in mention dropdown

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879c68afa7c832bbbd2b8ade31ac835