### PR TITLE
Implement Supabase auth integration

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -113,7 +113,8 @@ export default function SocialListeningApp({ onLogout }) {
     fetchMentions();
   }, []);
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
     if (onLogout) onLogout();
     navigate("/login");
   };

--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -2,15 +2,26 @@ import { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { supabase } from "@/lib/supabaseClient";
 
 export default function Login({ onLogin }) {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [error, setError] = useState(null);
   const navigate = useNavigate();
   const handleLogin = async (e) => {
     e.preventDefault();
-    if (onLogin) onLogin();
-    navigate("/home");
+    setError(null);
+    const { error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+    if (error) {
+      setError(error.message);
+    } else {
+      if (onLogin) onLogin();
+      navigate("/home");
+    }
   };
 
   return (
@@ -29,6 +40,7 @@ export default function Login({ onLogin }) {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
         />
+        {error && <p className="text-sm text-red-500 text-center">{error}</p>}
         <Button type="submit" className="w-full">
           Iniciar sesión
         </Button>

--- a/src/Register.jsx
+++ b/src/Register.jsx
@@ -1,15 +1,15 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
 import { supabase } from "@/lib/supabaseClient";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 
 export default function Register() {
+  const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [error, setError] = useState(null);
-  const navigate = useNavigate();
+  const [registered, setRegistered] = useState(false);
 
   const handleRegister = async (e) => {
     e.preventDefault();
@@ -22,11 +22,12 @@ export default function Register() {
     const { error } = await supabase.auth.signUp({
       email,
       password,
+      options: { data: { display_name: name } },
     });
     if (error) {
       setError(error.message);
     } else {
-      navigate("/login");
+      setRegistered(true);
     }
   };
 
@@ -34,6 +35,11 @@ export default function Register() {
     <div className="min-h-screen flex items-center justify-center bg-neutral-950 text-gray-100">
       <form onSubmit={handleRegister} className="bg-secondary p-8 rounded-lg space-y-4 shadow-md w-80">
         <h1 className="text-2xl font-bold text-center">Crear cuenta</h1>
+        <Input
+          placeholder="Nombre"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
         <Input
           placeholder="Correo electrónico"
           type="email"
@@ -53,6 +59,11 @@ export default function Register() {
           onChange={(e) => setConfirmPassword(e.target.value)}
         />
         {error && <p className="text-sm text-red-500 text-center">{error}</p>}
+        {registered && (
+          <p className="text-sm text-green-500 text-center">
+            Revisa tu correo para confirmar tu cuenta.
+          </p>
+        )}
         <Button type="submit" className="w-full">
           Registrarse
         </Button>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom/client';
 import SocialListeningApp from './App';
 import Login from './Login';
@@ -6,9 +6,22 @@ import Register from './Register';
 import './index.css';
 import { FavoritesProvider } from './context/FavoritesContext';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { supabase } from './lib/supabaseClient';
 
 function Root() {
   const [loggedIn, setLoggedIn] = useState(false);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      setLoggedIn(!!data.session);
+    });
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setLoggedIn(!!session);
+    });
+    return () => subscription.unsubscribe();
+  }, []);
 
   return (
     <FavoritesProvider>


### PR DESCRIPTION
## Summary
- store display name on sign up
- ask users to confirm their email after registering
- support Supabase sign-in
- track auth state and sign out

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879cf126c94832baaebb9deaf66fb41