### PR TITLE
Improve keyword error message

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -147,7 +147,7 @@ export default function SocialListeningApp({ onLogout }) {
       console.error("Error adding keyword", error);
       setKeywordMessage({
         type: "error",
-        text: "No se pudo agregar la keyword",
+        text: `No se pudo agregar la keyword: ${error?.message || "Error desconocido"}`,
       });
     } else {
       setKeywords((k) => [...data, ...k]);


### PR DESCRIPTION
## Summary
- show error message detail when adding a keyword fails

## Testing
- `npm run build` *(fails: esbuild platform mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_687aa0927d90832ba0e8eab24bb0d273