### PR TITLE
Add keyword dropdown and word cloud

### DIFF
--- a/src/components/WordCloud.jsx
+++ b/src/components/WordCloud.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+export default function WordCloud({ words = [] }) {
+  if (!words.length) {
+    return <p className="text-muted-foreground text-sm">Sin datos</p>;
+  }
+
+  const max = Math.max(...words.map((w) => w.value));
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {words.map((w, i) => {
+        const size = 0.75 + (w.value / max) * 1.25; // scale
+        return (
+          <span
+            key={i}
+            style={{ fontSize: `${size}rem` }}
+            className="text-primary"
+          >
+            {w.text}
+          </span>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add simple `WordCloud` component
- replace dashboard keyword search with dropdown listing active keywords
- remove the "ordenar por" filter
- show a basic word cloud on the first dashboard card

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687bd3dfc848832b874b9b34bba68087