### PR TITLE
Add active sources chart

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import MentionCard from "@/components/MentionCard";
 import WordCloud from "@/components/WordCloud";
 import PlatformBarChart from "@/components/PlatformBarChart";
+import ActiveSourcesBarChart from "@/components/ActiveSourcesBarChart";
 import MultiSelect from "@/components/MultiSelect";
 import { Button } from "@/components/ui/button";
 import RightSidebar from "@/components/RightSidebar";
@@ -323,6 +324,30 @@ export default function SocialListeningApp({ onLogout }) {
       .sort((a, b) => b.count - a.count);
   }, [mentions, selectedDashboardKeywords, selectedDashboardPlatforms]);
 
+  const sourceCounts = useMemo(() => {
+    const counts = {};
+    for (const m of mentions) {
+      if (
+        !selectedDashboardKeywords.includes("all") &&
+        !selectedDashboardKeywords.includes(m.keyword)
+      )
+        continue;
+      const platform = m.platform?.toLowerCase?.();
+      if (
+        !selectedDashboardPlatforms.includes("all") &&
+        !selectedDashboardPlatforms.includes(platform)
+      )
+        continue;
+      const name = m.source;
+      if (!name) continue;
+      counts[name] = (counts[name] || 0) + 1;
+    }
+    return Object.entries(counts)
+      .map(([name, count]) => ({ name, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 10);
+  }, [mentions, selectedDashboardKeywords, selectedDashboardPlatforms]);
+
   return (
     <div className="min-h-screen flex bg-neutral-950 text-gray-100 relative">
       <button
@@ -544,15 +569,21 @@ export default function SocialListeningApp({ onLogout }) {
                  </div>
                 </CardContent>
               </Card>
-              {[...Array(4)].map((_, i) => (
+              <Card className="bg-secondary h-[400px]">
+                <CardContent className="p-4 space-y-2 h-full flex flex-col">
+                  <p className="font-semibold">📌 Usuarios/canales más activos</p>
+                  <div className="flex-1">
+                    <ActiveSourcesBarChart data={sourceCounts} />
+                  </div>
+                </CardContent>
+              </Card>
+              {[...Array(3)].map((_, i) => (
                 <Card key={i} className="bg-secondary">
                   <CardContent className="p-4">
                     <p className="font-semibold">
-                      📌 Título de gráfico o insight {i + 3}
+                      📌 Título de gráfico o insight {i + 4}
                     </p>
-                    <p className="text-sm text-gray-600">
-                      Placeholder de gráfico o métrica
-                    </p>
+                    <p className="text-sm text-gray-600">Placeholder de gráfico o métrica</p>
                   </CardContent>
                 </Card>
               ))}

--- a/src/components/ActiveSourcesBarChart.jsx
+++ b/src/components/ActiveSourcesBarChart.jsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, CartesianGrid } from "recharts";
+
+export default function ActiveSourcesBarChart({ data = [] }) {
+  if (!data.length) {
+    return <p className="text-muted-foreground text-sm">Sin datos</p>;
+  }
+
+  return (
+    <div className="w-full h-full min-h-[300px]">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart
+          layout="vertical"
+          data={data}
+          margin={{ top: 10, right: 20, bottom: 10, left: 80 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+          <XAxis
+            type="number"
+            dataKey="count"
+            stroke="#9CA3AF"
+            tick={{ fontSize: 12 }}
+            axisLine={false}
+            tickLine={false}
+          />
+          <YAxis
+            type="category"
+            dataKey="name"
+            stroke="#9CA3AF"
+            tick={{ fontSize: 12 }}
+            axisLine={false}
+            tickLine={false}
+            width={100}
+          />
+          <Tooltip formatter={(value) => [value, "Menciones"]} />
+          <Bar dataKey="count" fill="#4F46E5" radius={[0, 4, 4, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ActiveSourcesBarChart` component with Recharts
- compute `sourceCounts` in dashboard
- render active sources bar chart in dashboard

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687dadee2f08832bb40a0a0e5e4bad66