### PR TITLE
Add mentions trend line chart

### DIFF
--- a/src/components/MentionsLineChart.jsx
+++ b/src/components/MentionsLineChart.jsx
@@ -1,0 +1,35 @@
+import React from "react";
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+} from "recharts";
+
+export default function MentionsLineChart({ data = [] }) {
+  if (!data.length) {
+    return <p className="text-muted-foreground text-sm">Sin datos</p>;
+  }
+
+  const formatDate = (d) => {
+    const date = new Date(d);
+    return date.toLocaleDateString();
+  };
+
+  return (
+    <div className="w-full h-full min-h-[300px]">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data} margin={{ top: 10, right: 20, bottom: 10, left: 20 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+          <XAxis dataKey="date" stroke="#9CA3AF" tick={{ fontSize: 12 }} axisLine={false} tickLine={false} />
+          <YAxis stroke="#9CA3AF" tick={{ fontSize: 12 }} axisLine={false} tickLine={false} allowDecimals={false} />
+          <Tooltip formatter={(value) => [value, "Menciones"]} labelFormatter={formatDate} />
+          <Line type="monotone" dataKey="count" stroke="#4F46E5" strokeWidth={2} dot={{ r: 3 }} />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add MentionsLineChart component using recharts
- compute mentionsOverTime data in the dashboard
- show the new line chart spanning full width of dashboard grid

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687db612f3c0832b9914a8129b4e321e