### PR TITLE
Enable dismiss in home mentions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -527,7 +527,9 @@ export default function SocialListeningApp({ onLogout }) {
                         content={m.mention}
                         keyword={m.keyword}
                         url={m.url}
-                        showDismiss={false}
+                        onHide={() =>
+                          setHiddenMentions((prev) => [...prev, m.url])
+                        }
                       />
                     ))
                   ) : (

--- a/src/components/MentionCard.jsx
+++ b/src/components/MentionCard.jsx
@@ -105,7 +105,7 @@ export default function MentionCard({
       <button
         onClick={handleFavClick}
         title="Agregar a favoritos"
-        className="absolute top-2 right-8 text-primary hover:text-primary/80"
+        className={`absolute top-2 ${showDismiss ? "right-8" : "right-2"} text-primary hover:text-primary/80`}
       >
         {favorite ? <FaHeart /> : <FaRegHeart />}
       </button>


### PR DESCRIPTION
## Summary
- show dismiss button in home mentions
- keep favorites unaffected
- tweak favorite button placement to fill dismiss slot

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68814d663cb4832b9c561650434de955