### PR TITLE
Improve dashboard charts

### DIFF
--- a/src/components/ActiveSourcesBarChart.jsx
+++ b/src/components/ActiveSourcesBarChart.jsx
@@ -1,5 +1,14 @@
 import React from "react";
-import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, CartesianGrid } from "recharts";
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+} from "recharts";
+import ChartTooltip from "./ChartTooltip";
 
 export default function ActiveSourcesBarChart({ data = [] }) {
   if (!data.length) {
@@ -32,7 +41,7 @@ export default function ActiveSourcesBarChart({ data = [] }) {
             tickLine={false}
             width={100}
           />
-          <Tooltip formatter={(value) => [value, "Menciones"]} />
+          <Tooltip content={<ChartTooltip />} />
           <Bar dataKey="count" fill="#4F46E5" radius={[0, 4, 4, 0]} />
         </BarChart>
       </ResponsiveContainer>

--- a/src/components/ChartTooltip.jsx
+++ b/src/components/ChartTooltip.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+export default function ChartTooltip({ active, payload, label }) {
+  if (!active || !payload || !payload.length) {
+    return null;
+  }
+
+  return (
+    <div className="bg-white/30 backdrop-blur-md rounded-md shadow-md px-2 py-1 text-xs text-white">
+      {label && <p className="font-medium mb-0">{label}</p>}
+      <p>{payload[0].value}</p>
+    </div>
+  );
+}

--- a/src/components/MentionsLineChart.jsx
+++ b/src/components/MentionsLineChart.jsx
@@ -8,6 +8,7 @@ import {
   Tooltip,
   CartesianGrid,
 } from "recharts";
+import ChartTooltip from "./ChartTooltip";
 
 export default function MentionsLineChart({ data = [] }) {
   if (!data.length) {
@@ -26,7 +27,7 @@ export default function MentionsLineChart({ data = [] }) {
           <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
           <XAxis dataKey="date" stroke="#9CA3AF" tick={{ fontSize: 12 }} axisLine={false} tickLine={false} />
           <YAxis stroke="#9CA3AF" tick={{ fontSize: 12 }} axisLine={false} tickLine={false} allowDecimals={false} />
-          <Tooltip formatter={(value) => [value, "Menciones"]} labelFormatter={formatDate} />
+          <Tooltip content={<ChartTooltip />} labelFormatter={formatDate} />
           <Line type="monotone" dataKey="count" stroke="#4F46E5" strokeWidth={2} dot={{ r: 3 }} />
         </LineChart>
       </ResponsiveContainer>

--- a/src/components/PlatformBarChart.jsx
+++ b/src/components/PlatformBarChart.jsx
@@ -1,21 +1,23 @@
 import React from "react";
-import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, CartesianGrid } from "recharts";
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+} from "recharts";
+import ChartTooltip from "./ChartTooltip";
 
 export default function PlatformBarChart({ data = [] }) {
   if (!data.length) {
     return <p className="text-muted-foreground text-sm">Sin datos</p>;
   }
 
-  const colors = {
-    twitter: "#1DA1F2",
-    youtube: "#FF0000",
-    reddit: "#FF5700",
-  };
-
   const formatted = data.map((d) => ({
     name: d.platform,
     count: d.count,
-    fill: colors[d.platform.toLowerCase()] || "#4F46E5",
   }));
 
   return (
@@ -25,8 +27,8 @@ export default function PlatformBarChart({ data = [] }) {
           <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
           <XAxis dataKey="name" stroke="#9CA3AF" tick={{ fontSize: 12 }} axisLine={false} tickLine={false} />
           <YAxis stroke="#9CA3AF" tick={{ fontSize: 12 }} axisLine={false} tickLine={false} />
-          <Tooltip />
-          <Bar dataKey="count" radius={[4, 4, 0, 0]} />
+          <Tooltip content={<ChartTooltip />} />
+          <Bar dataKey="count" fill="#4F46E5" radius={[4, 4, 0, 0]} />
         </BarChart>
       </ResponsiveContainer>
     </div>


### PR DESCRIPTION
## Summary
- unify bar colors for "Menciones por plataforma" with active sources chart
- add reusable translucent tooltip component
- apply the tooltip across all dashboard charts

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68815326b518832baf2b4661655d0360