### PR TITLE
Add calendar picker and month grouping

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Input } from "@/components/ui/input";
+import DatePickerInput from "@/components/DatePickerInput";
 import { Card, CardContent } from "@/components/ui/card";
 import MentionCard from "@/components/MentionCard";
 import WordCloud from "@/components/WordCloud";
@@ -616,18 +617,16 @@ export default function SocialListeningApp({ onLogout }) {
               <div>
                 <p className="text-sm font-medium mb-1">Rango de fechas</p>
                 <div className="flex items-center gap-2">
-                  <Input
-                    type="date"
+                  <DatePickerInput
                     value={startDate}
-                    onChange={(e) => setStartDate(e.target.value)}
+                    onChange={setStartDate}
                     placeholder="Desde"
                     className="w-40"
                   />
                   <span>a</span>
-                  <Input
-                    type="date"
+                  <DatePickerInput
                     value={endDate}
-                    onChange={(e) => setEndDate(e.target.value)}
+                    onChange={setEndDate}
                     placeholder="Hasta"
                     className="w-40"
                   />
@@ -693,7 +692,6 @@ export default function SocialListeningApp({ onLogout }) {
 
         {activeTab === "config" && (
           <section>
-            <h2 className="text-2xl font-bold mb-4">🛠️ Configuración</h2>
             <div className="space-y-6">
               <div>
                 <h3 className="text-lg font-semibold mb-2">Agregar nueva keyword</h3>

--- a/src/components/DatePickerInput.jsx
+++ b/src/components/DatePickerInput.jsx
@@ -1,0 +1,48 @@
+import { useState, useRef, useEffect } from "react";
+import { Input } from "@/components/ui/input";
+import { Calendar } from "@/components/ui/calendar";
+import { cn } from "@/lib/utils";
+
+export default function DatePickerInput({ value = "", onChange, placeholder = "", className = "" }) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (containerRef.current && !containerRef.current.contains(e.target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handleSelect = (date) => {
+    if (!date) return;
+    onChange && onChange(date.toISOString().slice(0, 10));
+    setOpen(false);
+  };
+
+  return (
+    <div ref={containerRef} className={cn("relative", className)}>
+      <Input
+        type="text"
+        readOnly
+        value={value}
+        onClick={() => setOpen((o) => !o)}
+        placeholder={placeholder}
+        className="cursor-pointer"
+      />
+      {open && (
+        <div className="absolute z-50 mt-1">
+          <Calendar
+            mode="single"
+            selected={value ? new Date(value) : undefined}
+            onSelect={handleSelect}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/components/MentionsLineChart.jsx
+++ b/src/components/MentionsLineChart.jsx
@@ -20,12 +20,29 @@ export default function MentionsLineChart({ data = [] }) {
     return date.toLocaleDateString();
   };
 
+  const formatMonth = (d) => {
+    const date = new Date(d);
+    return date.toLocaleString("default", { month: "short", year: "numeric" });
+  };
+
+  const monthTicks = Array.from(
+    new Set(data.map((d) => d.date.slice(0, 7)))
+  ).map((m) => `${m}-01`);
+
   return (
     <div className="w-full h-full min-h-[300px]">
       <ResponsiveContainer width="100%" height="100%">
         <LineChart data={data} margin={{ top: 10, right: 20, bottom: 10, left: 20 }}>
           <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
-          <XAxis dataKey="date" stroke="#9CA3AF" tick={{ fontSize: 12 }} axisLine={false} tickLine={false} />
+          <XAxis
+            dataKey="date"
+            ticks={monthTicks}
+            tickFormatter={formatMonth}
+            stroke="#9CA3AF"
+            tick={{ fontSize: 12 }}
+            axisLine={false}
+            tickLine={false}
+          />
           <YAxis stroke="#9CA3AF" tick={{ fontSize: 12 }} axisLine={false} tickLine={false} allowDecimals={false} />
           <Tooltip content={<ChartTooltip />} labelFormatter={formatDate} />
           <Line type="monotone" dataKey="count" stroke="#4F46E5" strokeWidth={2} dot={{ r: 3 }} />


### PR DESCRIPTION
## Summary
- remove configuration heading from config tab
- add DatePickerInput component
- integrate date picker on dashboard
- group line chart axis by month

## Testing
- `npm run build` *(fails: esbuild binary for darwin-arm64)*

------
https://chatgpt.com/codex/tasks/task_e_6881564c0a6c832b8b0fbf29fa10939d