### PR TITLE
Improve line chart formatting

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -597,7 +597,7 @@ export default function SocialListeningApp({ onLogout }) {
         )}
 
         {activeTab === "dashboard" && (
-          <section>
+          <section className="pr-4">
             <div className="flex flex-wrap gap-4 mb-4">
               <div>
                 <p className="text-sm font-medium mb-1">Palabras clave</p>
@@ -691,7 +691,7 @@ export default function SocialListeningApp({ onLogout }) {
         )}
 
         {activeTab === "config" && (
-          <section>
+          <section className="pr-4">
             <div className="space-y-6">
               <div>
                 <h3 className="text-lg font-semibold mb-2">Agregar nueva keyword</h3>

--- a/src/components/MentionsLineChart.jsx
+++ b/src/components/MentionsLineChart.jsx
@@ -15,19 +15,26 @@ export default function MentionsLineChart({ data = [] }) {
     return <p className="text-muted-foreground text-sm">Sin datos</p>;
   }
 
+  const months = Array.from(new Set(data.map((d) => d.date.slice(0, 7))));
+  const shortRange = months.length <= 2;
+
   const formatDate = (d) => {
     const date = new Date(d);
-    return date.toLocaleDateString();
+    return date.toLocaleDateString("es-ES", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    });
   };
 
-  const formatMonth = (d) => {
+  const formatTick = (d) => {
     const date = new Date(d);
-    return date.toLocaleString("default", { month: "short", year: "numeric" });
+    return shortRange
+      ? date.toLocaleDateString("es-ES", { day: "2-digit", month: "short" })
+      : date.toLocaleDateString("es-ES", { month: "short", year: "numeric" });
   };
 
-  const monthTicks = Array.from(
-    new Set(data.map((d) => d.date.slice(0, 7)))
-  ).map((m) => `${m}-01`);
+  const monthTicks = months.map((m) => `${m}-01`);
 
   return (
     <div className="w-full h-full min-h-[300px]">
@@ -36,12 +43,12 @@ export default function MentionsLineChart({ data = [] }) {
           <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
           <XAxis
             dataKey="date"
-            ticks={monthTicks}
-            tickFormatter={formatMonth}
+            tickFormatter={formatTick}
             stroke="#9CA3AF"
             tick={{ fontSize: 12 }}
             axisLine={false}
             tickLine={false}
+            {...(!shortRange && { ticks: monthTicks })}
           />
           <YAxis stroke="#9CA3AF" tick={{ fontSize: 12 }} axisLine={false} tickLine={false} allowDecimals={false} />
           <Tooltip content={<ChartTooltip />} labelFormatter={formatDate} />


### PR DESCRIPTION
## Summary
- improve MentionsLineChart date formatting to adapt to the range
- keep tooltip full date and only show month ticks when range is long
- add a small right padding on Dashboard and Config sections

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68816c7bc504832bbbe53f9f25634aa8