### PR TITLE
Add star filter and option menu

### DIFF
--- a/src/components/MentionCard.jsx
+++ b/src/components/MentionCard.jsx
@@ -5,15 +5,15 @@ import {
   FaTwitter,
   FaYoutube,
   FaRedditAlien,
+  FaEllipsisV,
   FaHeart,
-  FaRegHeart,
-  FaTimes,
   FaArrowUp,
   FaComment,
   FaRetweet,
   FaEye,
   FaQuoteRight,
 } from "react-icons/fa";
+import { Star, X } from "lucide-react";
 import { useFavorites } from "@/context/FavoritesContext";
 
 export default function MentionCard({
@@ -38,6 +38,7 @@ export default function MentionCard({
   const iconBg = icons[platform]?.bg;
   const iconSizeClass = "size-7";
   const [expanded, setExpanded] = useState(false);
+  const [optionsOpen, setOptionsOpen] = useState(false);
   const { toggleFavorite, isFavorite } = useFavorites();
   const favorite = isFavorite(mention);
 
@@ -90,25 +91,44 @@ export default function MentionCard({
       onClick={() => setExpanded((e) => !e)}
       className="relative border-muted bg-secondary hover:bg-secondary/70 transition-colors rounded-lg cursor-pointer"
     >
-      {showDismiss && (
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            if (onHide) onHide();
-          }}
-          title="Marcar como irrelevante"
-          className="absolute top-2 right-2 text-primary hover:text-primary/80"
-        >
-          <FaTimes />
-        </button>
-      )}
       <button
-        onClick={handleFavClick}
-        title="Agregar a favoritos"
-        className={`absolute top-2 ${showDismiss ? "right-8" : "right-2"} text-primary hover:text-primary/80`}
+        onClick={(e) => {
+          e.stopPropagation();
+          setOptionsOpen((o) => !o);
+        }}
+        title="Opciones"
+        className="absolute top-2 right-2 text-primary hover:text-primary/80"
       >
-        {favorite ? <FaHeart /> : <FaRegHeart />}
+        <FaEllipsisV />
       </button>
+      {optionsOpen && (
+        <div className="absolute right-2 top-8 bg-secondary shadow-md rounded p-2 space-y-1 z-50">
+          {showDismiss && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setOptionsOpen(false);
+                if (onHide) onHide();
+              }}
+              className="flex items-center gap-2 w-full text-left p-2 rounded hover:bg-[#2E2E2E]"
+            >
+              <X className="size-4" />
+              Marcar como irrelevante
+            </button>
+          )}
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              setOptionsOpen(false);
+              handleFavClick(e);
+            }}
+            className="flex items-center gap-2 w-full text-left p-2 rounded hover:bg-[#2E2E2E]"
+          >
+            <Star className="size-4" />
+            Agregar a destacados
+          </button>
+        </div>
+      )}
       <CardContent className="p-6 flex gap-4">
         <div
           className={`w-10 h-10 flex items-center justify-center rounded-full shrink-0 ${!iconBg ? "bg-muted" : ""}`}

--- a/src/components/RightSidebar.jsx
+++ b/src/components/RightSidebar.jsx
@@ -2,7 +2,7 @@ import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { FilterX, Search } from "lucide-react";
+import { FilterX, Search, Star } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export default function RightSidebar({
@@ -14,6 +14,8 @@ export default function RightSidebar({
   sources,
   toggleSource,
   clearFilters,
+  onlyFavorites,
+  toggleFavorites,
 }) {
 
   const handleClearFilters = () => {
@@ -36,6 +38,14 @@ export default function RightSidebar({
           className="pl-9"
         />
       </div>
+      <Button
+        variant={onlyFavorites ? "default" : "outline"}
+        onClick={toggleFavorites}
+        className="w-full flex items-center gap-2 justify-start"
+      >
+        <Star className="size-4" />
+        Destacados
+      </Button>
       <div>
         <p className="font-semibold mb-2">Rango de tiempo</p>
         <Select value={range} onValueChange={setRange}>


### PR DESCRIPTION
## Summary
- remove old favorites tab UI
- add options menu with dismiss and star to each mention card
- allow filtering by favorites from right sidebar

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68819b940364832b961f9175a09a000e