### PR TITLE
Move search bar above mentions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -483,6 +483,15 @@ export default function SocialListeningApp({ onLogout }) {
               </div>
               <div className="flex items-start gap-8">
                 <div className="flex-1 flex flex-col gap-6">
+                  <div className="relative">
+                    <Search className="absolute left-3 top-2.5 size-4 text-muted-foreground" />
+                    <Input
+                      placeholder="Buscar..."
+                      value={search}
+                      onChange={(e) => setSearch(e.target.value)}
+                      className="pl-9"
+                    />
+                  </div>
                   {homeMentions.length ? (
                     homeMentions.map((m, i) => (
                       <MentionCard
@@ -510,8 +519,6 @@ export default function SocialListeningApp({ onLogout }) {
                 </div>
                 <RightSidebar
                   className="mt-0 ml-auto"
-                  search={search}
-                  onSearchChange={setSearch}
                   range={rangeFilter}
                   setRange={setRangeFilter}
                   sources={sourcesFilter}

--- a/src/components/RightSidebar.jsx
+++ b/src/components/RightSidebar.jsx
@@ -1,14 +1,11 @@
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { FilterX, Search, Star } from "lucide-react";
+import { FilterX, Star } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export default function RightSidebar({
   className = "",
-  search,
-  onSearchChange,
   range,
   setRange,
   sources,
@@ -29,15 +26,6 @@ export default function RightSidebar({
         className
       )}
     >
-      <div className="relative">
-        <Search className="absolute left-3 top-2.5 size-4 text-muted-foreground" />
-        <Input
-          placeholder="Buscar..."
-          value={search}
-          onChange={(e) => onSearchChange(e.target.value)}
-          className="pl-9"
-        />
-      </div>
       <Button
         variant={onlyFavorites ? "default" : "outline"}
         onClick={toggleFavorites}


### PR DESCRIPTION
## Summary
- reposition search bar to top of the mention list
- clean up RightSidebar props and remove search input

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68841e7d1e7c832b83d949f675f9d589