### PR TITLE
Add keyword filter and adjust UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import {
   Home,
   BarChart2,
   Settings,
+  Star,
 } from "lucide-react";
 import { useFavorites } from "@/context/FavoritesContext";
 import { formatDistanceToNow } from "date-fns";
@@ -35,6 +36,7 @@ export default function SocialListeningApp({ onLogout }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [rangeFilter, setRangeFilter] = useState("");
   const [sourcesFilter, setSourcesFilter] = useState([]);
+  const [keywordsFilter, setKeywordsFilter] = useState(["all"]);
   const [order, setOrder] = useState("recent");
   const [hiddenMentions, setHiddenMentions] = useState([]);
   const [keywords, setKeywords] = useState([]);
@@ -66,7 +68,9 @@ export default function SocialListeningApp({ onLogout }) {
         return diff <= days;
       })();
 
-    return matchesSearch && matchesSource && matchesRange;
+    const matchesKeyword =
+      keywordsFilter.includes("all") || keywordsFilter.includes(m.keyword);
+    return matchesSearch && matchesSource && matchesRange && matchesKeyword;
   });
 
   const sortedMentions = [...filteredMentions].sort((a, b) => {
@@ -226,6 +230,7 @@ export default function SocialListeningApp({ onLogout }) {
     setRangeFilter("");
     setSourcesFilter([]);
     setSearch("");
+    setKeywordsFilter(["all"]);
   };
 
   const activeKeywords = useMemo(
@@ -483,13 +488,21 @@ export default function SocialListeningApp({ onLogout }) {
                     className="pl-9 bg-secondary"
                   />
                 </div>
-                <div className="flex justify-start mb-4">
+                <div className="flex items-center justify-between mb-4">
                   <Tabs value={order} onValueChange={setOrder}>
                     <TabsList>
                       <TabsTrigger value="recent">Más recientes</TabsTrigger>
                       <TabsTrigger value="popular">Más populares</TabsTrigger>
                     </TabsList>
                   </Tabs>
+                  <Button
+                    variant={onlyFavorites ? "default" : "outline"}
+                    onClick={() => setOnlyFavorites((o) => !o)}
+                    className="flex items-center gap-2"
+                  >
+                    <Star className="size-4" />
+                    Ver solo destacados
+                  </Button>
                 </div>
                 <div className="flex flex-col gap-6">
                   {homeMentions.length ? (
@@ -524,9 +537,10 @@ export default function SocialListeningApp({ onLogout }) {
                 setRange={setRangeFilter}
                 sources={sourcesFilter}
                 toggleSource={toggleSourceFilter}
+                keywords={keywordsFilter}
+                setKeywords={setKeywordsFilter}
+                keywordOptions={activeKeywords}
                 clearFilters={clearSidebarFilters}
-                onlyFavorites={onlyFavorites}
-                toggleFavorites={() => setOnlyFavorites((o) => !o)}
               />
             </div>
           </section>

--- a/src/components/RightSidebar.jsx
+++ b/src/components/RightSidebar.jsx
@@ -1,8 +1,9 @@
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
-import { FilterX, Star } from "lucide-react";
+import { FilterX } from "lucide-react";
 import { cn } from "@/lib/utils";
+import MultiSelect from "@/components/MultiSelect";
 
 export default function RightSidebar({
   className = "",
@@ -10,9 +11,10 @@ export default function RightSidebar({
   setRange,
   sources,
   toggleSource,
+  keywords,
+  setKeywords,
+  keywordOptions = [],
   clearFilters,
-  onlyFavorites,
-  toggleFavorites,
 }) {
 
   const handleClearFilters = () => {
@@ -22,18 +24,10 @@ export default function RightSidebar({
   return (
     <aside
       className={cn(
-        "w-64 bg-secondary shadow-md p-6 space-y-6 flex flex-col items-start rounded-lg self-start sticky top-8 h-[calc(100vh-2rem)]",
+        "w-64 bg-secondary shadow-md p-6 space-y-6 flex flex-col items-start rounded-lg self-start sticky top-24 h-[calc(100vh-6rem)]",
         className
       )}
     >
-      <Button
-        variant={onlyFavorites ? "default" : "outline"}
-        onClick={toggleFavorites}
-        className="w-full flex items-center gap-2 justify-start"
-      >
-        <Star className="size-4" />
-        Destacados
-      </Button>
       <div>
         <p className="font-semibold mb-2">Rango de tiempo</p>
         <Select value={range} onValueChange={setRange}>
@@ -47,6 +41,21 @@ export default function RightSidebar({
           </SelectContent>
         </Select>
       </div>
+      <div className="border-t border-border/50 w-full" />
+
+      <div>
+        <p className="font-semibold mb-2">Palabras clave</p>
+        <MultiSelect
+          options={[
+            { value: "all", label: "Todas" },
+            ...keywordOptions.map((k) => ({ value: k.keyword, label: k.keyword })),
+          ]}
+          value={keywords}
+          onChange={setKeywords}
+          className="w-full"
+        />
+      </div>
+      <div className="border-t border-border/50 w-full" />
 
 
       <div>
@@ -69,6 +78,8 @@ export default function RightSidebar({
         </div>
       </div>
 
+      <div className="border-t border-border/50 w-full" />
+
       <div>
         <p className="font-semibold mb-2">Sentimiento</p>
         <div className="space-y-2">
@@ -86,6 +97,8 @@ export default function RightSidebar({
           </label>
         </div>
       </div>
+
+      <div className="border-t border-border/50 w-full" />
 
       <Button
         variant="outline"


### PR DESCRIPTION
## Summary
- move favorites toggle next to the mentions order control
- add keyword multi-select filter in the sidebar
- visually separate sidebar filters and adjust sticky offset

## Testing
- `npm run build` *(fails: Rollup failed to resolve import `react-router-dom`)*

------
https://chatgpt.com/codex/tasks/task_e_6885a92ab0e0832ba6403eea17f77243