### PR TITLE
Fix sidebar spacing and style favorites button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import ActiveSourcesBarChart from "@/components/ActiveSourcesBarChart";
 import MentionsLineChart from "@/components/MentionsLineChart";
 import MultiSelect from "@/components/MultiSelect";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import RightSidebar from "@/components/RightSidebar";
 import { supabase } from "@/lib/supabaseClient";
 import {
@@ -496,9 +497,13 @@ export default function SocialListeningApp({ onLogout }) {
                     </TabsList>
                   </Tabs>
                   <Button
-                    variant={onlyFavorites ? "default" : "outline"}
                     onClick={() => setOnlyFavorites((o) => !o)}
-                    className="flex items-center gap-2"
+                    className={cn(
+                      "flex items-center gap-2 h-9 px-3 py-1 text-sm font-medium rounded-md transition-all",
+                      onlyFavorites
+                        ? "bg-background text-foreground shadow"
+                        : "bg-muted text-muted-foreground"
+                    )}
                   >
                     <Star className="size-4" />
                     Ver solo destacados

--- a/src/components/RightSidebar.jsx
+++ b/src/components/RightSidebar.jsx
@@ -24,14 +24,14 @@ export default function RightSidebar({
   return (
     <aside
       className={cn(
-        "w-64 bg-secondary shadow-md p-6 space-y-6 flex flex-col items-start rounded-lg self-start sticky top-24 h-[calc(100vh-6rem)]",
+        "w-64 bg-secondary shadow-md p-6 space-y-4 flex flex-col items-start rounded-lg self-start sticky top-[104px] h-[calc(100vh-6.5rem)]",
         className
       )}
     >
       <div>
         <p className="font-semibold mb-2">Rango de tiempo</p>
         <Select value={range} onValueChange={setRange}>
-          <SelectTrigger>
+          <SelectTrigger className="w-full">
             <SelectValue placeholder="Seleccionar" />
           </SelectTrigger>
           <SelectContent>


### PR DESCRIPTION
## Summary
- make right sidebar compact with space-y-4
- align sidebar with top of first mention
- make selects fill sidebar width
- style "Ver solo destacados" button like segmented control

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6885ab960dc0832b95f21f07c45db251