### PR TITLE
Improve favorites UI and sidebar layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -478,7 +478,7 @@ export default function SocialListeningApp({ onLogout }) {
       <main className="flex-1 p-8 pr-0 overflow-y-auto">
         {activeTab === "home" && (
           <section>
-            <div className="flex items-start gap-8">
+            <div className="flex items-start gap-8 min-h-screen">
               <div className="flex-1">
                 <div className="relative mb-4">
                   <Search className="absolute left-3 top-2.5 size-4 text-muted-foreground" />
@@ -501,7 +501,7 @@ export default function SocialListeningApp({ onLogout }) {
                     className={cn(
                       "flex items-center gap-2 h-9 px-3 py-1 text-sm font-medium rounded-md transition-all",
                       onlyFavorites
-                        ? "bg-background text-foreground shadow"
+                        ? "bg-accent text-accent-foreground shadow"
                         : "bg-muted text-muted-foreground"
                     )}
                   >

--- a/src/components/MentionCard.jsx
+++ b/src/components/MentionCard.jsx
@@ -125,7 +125,7 @@ export default function MentionCard({
             className="flex items-center gap-2 w-full text-left p-2 rounded hover:bg-[#2E2E2E]"
           >
             <Star className="size-4" />
-            Agregar a destacados
+            {favorite ? "Remover de destacados" : "Agregar a destacados"}
           </button>
         </div>
       )}


### PR DESCRIPTION
## Summary
- update MentionCard to show "Remover de destacados" when already favorite
- highlight the "Ver solo destacados" toggle using accent background
- keep sidebar position when filtering favorites by setting container min height

## Testing
- `npm rebuild esbuild`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6886626329c0832b8000f9974ccd2d93