### PR TITLE
Add last extraction date to keywords table

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -131,7 +131,9 @@ export default function SocialListeningApp({ onLogout }) {
   const fetchKeywords = async () => {
     const { data, error } = await supabase
       .from("dim_keywords")
-      .select("keyword, keyword_id, created_at, active")
+      .select(
+        "keyword, keyword_id, created_at, active, last_processed_at_yt, last_processed_at_rd, last_processed_at_tw",
+      )
       .order("created_at", { ascending: false });
     if (error) {
       console.error("Error fetching keywords", error);

--- a/src/components/KeywordTable.jsx
+++ b/src/components/KeywordTable.jsx
@@ -2,6 +2,7 @@ import { format } from "date-fns"
 import { es } from "date-fns/locale"
 import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from "@/components/ui/table"
 import { Switch } from "@/components/ui/switch"
+import { Power } from "lucide-react"
 
 export default function KeywordTable({ keywords, onToggle }) {
   const handleToggle = (id, current) => {
@@ -14,24 +15,45 @@ export default function KeywordTable({ keywords, onToggle }) {
         <TableRow>
           <TableHead>Keyword</TableHead>
           <TableHead>Fecha de creación</TableHead>
+          <TableHead>Última extracción de datos</TableHead>
           <TableHead>Estado</TableHead>
-          <TableHead className="text-right">&nbsp;</TableHead>
+          <TableHead className="text-right">
+            <Power className="w-4 h-4 inline" />
+          </TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
-        {keywords.map((k) => (
-          <TableRow key={k.keyword_id}>
-            <TableCell className="font-medium">{k.keyword}</TableCell>
-            <TableCell>{format(new Date(k.created_at), "dd/MM/yyyy", { locale: es })}</TableCell>
-            <TableCell>{k.active ? "Activo" : "Inactivo"}</TableCell>
-            <TableCell className="text-right">
-              <Switch
-                checked={k.active}
-                onCheckedChange={() => handleToggle(k.keyword_id, k.active)}
-              />
-            </TableCell>
-          </TableRow>
-        ))}
+        {keywords.map((k) => {
+          const dates = [
+            k.last_processed_at_yt,
+            k.last_processed_at_rd,
+            k.last_processed_at_tw,
+          ]
+            .filter(Boolean)
+            .map((d) => new Date(d))
+          const lastDate =
+            dates.length > 0 ? new Date(Math.max(...dates)) : null
+          return (
+            <TableRow key={k.keyword_id}>
+              <TableCell className="font-medium">{k.keyword}</TableCell>
+              <TableCell>
+                {format(new Date(k.created_at), "dd/MM/yyyy", { locale: es })}
+              </TableCell>
+              <TableCell>
+                {lastDate
+                  ? format(lastDate, "dd/MM/yyyy HH:mm", { locale: es })
+                  : "-"}
+              </TableCell>
+              <TableCell>{k.active ? "Activo" : "Inactivo"}</TableCell>
+              <TableCell className="text-right">
+                <Switch
+                  checked={k.active}
+                  onCheckedChange={() => handleToggle(k.keyword_id, k.active)}
+                />
+              </TableCell>
+            </TableRow>
+          )
+        })}
       </TableBody>
     </Table>
   )


### PR DESCRIPTION
## Summary
- fetch processing timestamps for keywords
- compute latest data extraction date for each keyword
- show power icon in keyword table header

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688672f268d8832ba2250ddd91b3b605