### PR TITLE
Add custom reports table with creation flow

### DIFF
--- a/src/components/ReportsTable.jsx
+++ b/src/components/ReportsTable.jsx
@@ -1,0 +1,44 @@
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+
+export default function ReportsTable({ reports = [], onDownload }) {
+  return (
+    <Table className="bg-secondary rounded-md text-sm">
+      <TableHeader>
+        <TableRow>
+          <TableHead>Nombre</TableHead>
+          <TableHead>Plataformas</TableHead>
+          <TableHead>Rango de fechas</TableHead>
+          <TableHead>Comentarios</TableHead>
+          <TableHead className="text-right">Descargar</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {reports.map((r, idx) => (
+          <TableRow key={idx}>
+            <TableCell className="font-medium">{r.name}</TableCell>
+            <TableCell>{r.platforms.join(', ') || '-'}</TableCell>
+            <TableCell>
+              {r.datePreset
+                ? `Últimos ${r.datePreset} días`
+                : `${r.startDate || '-'} a ${r.endDate || '-'}`}
+            </TableCell>
+            <TableCell>
+              {[
+                r.includeYoutubeComments && 'YouTube',
+                r.includeRedditComments && 'Reddit',
+              ]
+                .filter(Boolean)
+                .join(', ') || 'No'}
+            </TableCell>
+            <TableCell className="text-right">
+              <Button size="sm" onClick={() => onDownload && onDownload(r)}>
+                Descargar
+              </Button>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}


### PR DESCRIPTION
## Summary
- enable persisting user reports
- add ReportsTable component for viewing reports
- implement create-report workflow with optional date presets

## Testing
- `npm run build` *(fails: esbuild platform mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6888482a0d94832b8864b59cacc20d2e