### PR TITLE
Update reports table layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -775,7 +775,7 @@ export default function SocialListeningApp({ onLogout }) {
         )}
 
         {activeTab === "reportes" && (
-          <section className="pr-4 max-w-xl space-y-6">
+          <section className="pr-4 space-y-6 pb-4">
             <h2 className="text-2xl font-bold mb-4">Mis reportes</h2>
             <ReportsTable reports={savedReports} onDownload={handleDownloadReport} />
             <Button variant="outline" type="button" onClick={() => setShowReportForm((s) => !s)}>

--- a/src/components/ReportsTable.jsx
+++ b/src/components/ReportsTable.jsx
@@ -17,20 +17,27 @@ export default function ReportsTable({ reports = [], onDownload }) {
         {reports.map((r, idx) => (
           <TableRow key={idx}>
             <TableCell className="font-medium">{r.name}</TableCell>
-            <TableCell>{r.platforms.join(', ') || '-'}</TableCell>
+              <TableCell>
+                {r.platforms
+                  .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+                  .join(', ') || '-'}
+              </TableCell>
             <TableCell>
               {r.datePreset
                 ? `Últimos ${r.datePreset} días`
                 : `${r.startDate || '-'} a ${r.endDate || '-'}`}
             </TableCell>
-            <TableCell>
-              {[
-                r.includeYoutubeComments && 'YouTube',
-                r.includeRedditComments && 'Reddit',
-              ]
-                .filter(Boolean)
-                .join(', ') || 'No'}
-            </TableCell>
+              <TableCell>
+                {(() => {
+                  const platforms = [
+                    r.includeYoutubeComments && 'YouTube',
+                    r.includeRedditComments && 'Reddit',
+                  ].filter(Boolean);
+                  return platforms.length
+                    ? `Si (${platforms.join(', ')})`
+                    : 'No';
+                })()}
+              </TableCell>
             <TableCell className="text-right">
               <Button size="sm" onClick={() => onDownload && onDownload(r)}>
                 Descargar


### PR DESCRIPTION
## Summary
- stretch Reports table section to match Config section width
- display comment information as `Si (Plataformas)` instead of listing
- capitalize platform names in saved reports

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68884a60a350832ba22d96d792c4f2c7