### PR TITLE
Add report deletion

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -359,6 +359,10 @@ export default function SocialListeningApp({ onLogout }) {
     console.log("Download", rep);
   };
 
+  const handleDeleteReport = (index) => {
+    setSavedReports((prev) => prev.filter((_, i) => i !== index));
+  };
+
   const activeKeywords = useMemo(
     () => keywords.filter((k) => k.active),
     [keywords],
@@ -777,7 +781,11 @@ export default function SocialListeningApp({ onLogout }) {
         {activeTab === "reportes" && (
           <section className="pr-4 space-y-6 pb-4">
             <h2 className="text-2xl font-bold mb-4">Mis reportes</h2>
-            <ReportsTable reports={savedReports} onDownload={handleDownloadReport} />
+            <ReportsTable
+              reports={savedReports}
+              onDownload={handleDownloadReport}
+              onDelete={handleDeleteReport}
+            />
             <Button variant="outline" type="button" onClick={() => setShowReportForm((s) => !s)}>
               Crear nuevo reporte
             </Button>

--- a/src/components/ReportsTable.jsx
+++ b/src/components/ReportsTable.jsx
@@ -1,7 +1,7 @@
 import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
-
-export default function ReportsTable({ reports = [], onDownload }) {
+import { X } from "lucide-react";
+export default function ReportsTable({ reports = [], onDownload, onDelete }) {
   return (
     <Table className="bg-secondary rounded-md text-sm">
       <TableHeader>
@@ -11,6 +11,9 @@ export default function ReportsTable({ reports = [], onDownload }) {
           <TableHead>Rango de fechas</TableHead>
           <TableHead>Comentarios</TableHead>
           <TableHead className="text-right">Descargar</TableHead>
+          <TableHead className="text-right">
+            <X className="w-4 h-4 inline" />
+          </TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -41,6 +44,15 @@ export default function ReportsTable({ reports = [], onDownload }) {
             <TableCell className="text-right">
               <Button size="sm" onClick={() => onDownload && onDownload(r)}>
                 Descargar
+              </Button>
+            </TableCell>
+            <TableCell className="text-right">
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => onDelete && onDelete(idx)}
+              >
+                <X className="w-4 h-4" />
               </Button>
             </TableCell>
           </TableRow>


### PR DESCRIPTION
## Summary
- enable deletion of saved reports by adding delete actions to the reports table

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68884c09abf8832bab396cda8fc56baa