### PR TITLE
Fix report table headers and comment options

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -807,7 +807,11 @@ export default function SocialListeningApp({ onLogout }) {
                         id="rep-yt"
                         checked={reportPlatforms.youtube}
                         onCheckedChange={() =>
-                          setReportPlatforms((p) => ({ ...p, youtube: !p.youtube }))
+                          setReportPlatforms((p) => {
+                            const newVal = !p.youtube;
+                            if (!newVal) setIncludeYoutubeComments(false);
+                            return { ...p, youtube: newVal };
+                          })
                         }
                       />
                       <span>YouTube</span>
@@ -817,7 +821,11 @@ export default function SocialListeningApp({ onLogout }) {
                         id="rep-re"
                         checked={reportPlatforms.reddit}
                         onCheckedChange={() =>
-                          setReportPlatforms((p) => ({ ...p, reddit: !p.reddit }))
+                          setReportPlatforms((p) => {
+                            const newVal = !p.reddit;
+                            if (!newVal) setIncludeRedditComments(false);
+                            return { ...p, reddit: newVal };
+                          })
                         }
                       />
                       <span>Reddit</span>
@@ -877,6 +885,7 @@ export default function SocialListeningApp({ onLogout }) {
                         onCheckedChange={() =>
                           setIncludeYoutubeComments((c) => !c)
                         }
+                        disabled={!reportPlatforms.youtube}
                       />
                       <span>Incluir comentarios de YouTube</span>
                     </label>
@@ -887,6 +896,7 @@ export default function SocialListeningApp({ onLogout }) {
                         onCheckedChange={() =>
                           setIncludeRedditComments((c) => !c)
                         }
+                        disabled={!reportPlatforms.reddit}
                       />
                       <span>Incluir comentarios de Reddit</span>
                     </label>

--- a/src/components/ReportsTable.jsx
+++ b/src/components/ReportsTable.jsx
@@ -10,10 +10,8 @@ export default function ReportsTable({ reports = [], onDownload, onDelete }) {
           <TableHead>Plataformas</TableHead>
           <TableHead>Rango de fechas</TableHead>
           <TableHead>Comentarios</TableHead>
-          <TableHead className="text-right">Descargar</TableHead>
-          <TableHead className="text-right">
-            <X className="w-4 h-4 inline" />
-          </TableHead>
+          <TableHead className="text-right"></TableHead>
+          <TableHead className="text-right"></TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -32,12 +30,15 @@ export default function ReportsTable({ reports = [], onDownload, onDelete }) {
             </TableCell>
               <TableCell>
                 {(() => {
-                  const platforms = [
+                  const commentPlatforms = [
                     r.includeYoutubeComments && 'YouTube',
                     r.includeRedditComments && 'Reddit',
                   ].filter(Boolean);
-                  return platforms.length
-                    ? `Si (${platforms.join(', ')})`
+                  if (r.platforms.includes('twitter') && commentPlatforms.length === 0) {
+                    return 'N/A';
+                  }
+                  return commentPlatforms.length
+                    ? `Si (${commentPlatforms.join(', ')})`
                     : 'No';
                 })()}
               </TableCell>


### PR DESCRIPTION
## Summary
- remove text from download/delete headers in ReportsTable
- display `N/A` for Twitter reports without comment platforms
- disable YouTube/Reddit comment options unless their platform is selected
- clear comment option when unselecting its platform

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68884dd12e4c832b8f99f58eb96c368f