### PR TITLE
Add keywords selection to reports

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -84,6 +84,7 @@ export default function SocialListeningApp({ onLogout }) {
   });
   const [showReportForm, setShowReportForm] = useState(false);
   const [newReportName, setNewReportName] = useState("");
+  const [reportKeywords, setReportKeywords] = useState([]);
   const [reportDateOption, setReportDateOption] = useState("range");
   const filteredMentions = mentions.filter((m) => {
     const matchesSearch =
@@ -338,6 +339,7 @@ export default function SocialListeningApp({ onLogout }) {
     const newRep = {
       name: newReportName || `Reporte ${savedReports.length + 1}`,
       platforms,
+      keywords: reportKeywords,
       startDate: reportDateOption === "range" ? reportStartDate : "",
       endDate: reportDateOption === "range" ? reportEndDate : "",
       datePreset: reportDateOption !== "range" ? reportDateOption : "",
@@ -347,6 +349,7 @@ export default function SocialListeningApp({ onLogout }) {
     setSavedReports((prev) => [...prev, newRep]);
     setNewReportName("");
     setReportPlatforms({ youtube: false, reddit: false, twitter: false });
+    setReportKeywords([]);
     setReportStartDate("");
     setReportEndDate("");
     setReportDateOption("range");
@@ -841,6 +844,18 @@ export default function SocialListeningApp({ onLogout }) {
                       <span>Twitter</span>
                     </label>
                   </div>
+                </div>
+                <div>
+                  <p className="text-sm font-medium mb-1">Palabras clave</p>
+                  <MultiSelect
+                    className="w-full"
+                    options={activeKeywords.map((k) => ({
+                      value: k.keyword,
+                      label: k.keyword,
+                    }))}
+                    value={reportKeywords}
+                    onChange={setReportKeywords}
+                  />
                 </div>
                 <div>
                   <p className="text-sm font-medium mb-1">Rango de fechas</p>

--- a/src/components/ReportsTable.jsx
+++ b/src/components/ReportsTable.jsx
@@ -8,6 +8,7 @@ export default function ReportsTable({ reports = [], onDownload, onDelete }) {
         <TableRow>
           <TableHead>Nombre</TableHead>
           <TableHead>Plataformas</TableHead>
+          <TableHead>Palabras clave</TableHead>
           <TableHead>Rango de fechas</TableHead>
           <TableHead>Comentarios</TableHead>
           <TableHead className="text-right"></TableHead>
@@ -18,30 +19,31 @@ export default function ReportsTable({ reports = [], onDownload, onDelete }) {
         {reports.map((r, idx) => (
           <TableRow key={idx}>
             <TableCell className="font-medium">{r.name}</TableCell>
-              <TableCell>
-                {r.platforms
-                  .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
-                  .join(', ') || '-'}
-              </TableCell>
+            <TableCell>
+              {r.platforms
+                .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+                .join(', ') || '-'}
+            </TableCell>
+            <TableCell>{r.keywords?.join(', ') || '-'}</TableCell>
             <TableCell>
               {r.datePreset
                 ? `Últimos ${r.datePreset} días`
                 : `${r.startDate || '-'} a ${r.endDate || '-'}`}
             </TableCell>
-              <TableCell>
-                {(() => {
-                  const commentPlatforms = [
-                    r.includeYoutubeComments && 'YouTube',
-                    r.includeRedditComments && 'Reddit',
-                  ].filter(Boolean);
-                  if (r.platforms.includes('twitter') && commentPlatforms.length === 0) {
-                    return 'N/A';
-                  }
-                  return commentPlatforms.length
-                    ? `Si (${commentPlatforms.join(', ')})`
-                    : 'No';
-                })()}
-              </TableCell>
+            <TableCell>
+              {(() => {
+                const commentPlatforms = [
+                  r.includeYoutubeComments && 'YouTube',
+                  r.includeRedditComments && 'Reddit',
+                ].filter(Boolean);
+                if (r.platforms.includes('twitter') && commentPlatforms.length === 0) {
+                  return 'N/A';
+                }
+                return commentPlatforms.length
+                  ? `Si (${commentPlatforms.join(', ')})`
+                  : 'No';
+              })()}
+            </TableCell>
             <TableCell className="text-right">
               <Button size="sm" onClick={() => onDownload && onDownload(r)}>
                 Descargar


### PR DESCRIPTION
## Summary
- add Palabras clave column to Mis reportes table
- allow selecting keywords when creating a new report

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688976a4a510832b85d8a84c3a73e642