### PR TITLE
feat: unify background palette

### DIFF
--- a/src/components/KeywordTable.jsx
+++ b/src/components/KeywordTable.jsx
@@ -10,7 +10,7 @@ export default function KeywordTable({ keywords, onToggle }) {
   }
 
   return (
-    <Table className="bg-secondary rounded-md text-sm">
+    <Table className="bg-card rounded-md text-sm">
       <TableHeader>
         <TableRow>
           <TableHead>Keyword</TableHead>

--- a/src/components/MentionCard.jsx
+++ b/src/components/MentionCard.jsx
@@ -89,7 +89,7 @@ export default function MentionCard({
   return (
     <Card
       onClick={() => setExpanded((e) => !e)}
-      className="relative border-muted bg-secondary hover:bg-secondary/70 transition-colors rounded-lg cursor-pointer"
+      className="relative border-muted bg-card hover:bg-muted transition-colors rounded-lg cursor-pointer"
     >
       <button
         onClick={(e) => {
@@ -102,7 +102,7 @@ export default function MentionCard({
         <FaEllipsisV />
       </button>
       {optionsOpen && (
-        <div className="absolute right-2 top-8 bg-secondary shadow-md rounded p-2 space-y-1 z-50">
+        <div className="absolute right-2 top-8 bg-card shadow-md rounded p-2 space-y-1 z-50">
           {showDismiss && (
             <button
               onClick={(e) => {
@@ -110,7 +110,7 @@ export default function MentionCard({
                 setOptionsOpen(false);
                 if (onHide) onHide();
               }}
-              className="flex items-center gap-2 w-full text-left p-2 rounded hover:bg-[#2E2E2E]"
+              className="flex items-center gap-2 w-full text-left p-2 rounded hover:bg-muted"
             >
               <X className="size-4" />
               Marcar como irrelevante
@@ -122,7 +122,7 @@ export default function MentionCard({
               setOptionsOpen(false);
               handleFavClick(e);
             }}
-            className="flex items-center gap-2 w-full text-left p-2 rounded hover:bg-[#2E2E2E]"
+            className="flex items-center gap-2 w-full text-left p-2 rounded hover:bg-muted"
           >
             <Star className="size-4" />
             {favorite ? "Remover de destacados" : "Agregar a destacados"}

--- a/src/components/ReportsTable.jsx
+++ b/src/components/ReportsTable.jsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { X } from "lucide-react";
 export default function ReportsTable({ reports = [], onDownload, onDelete }) {
   return (
-    <Table className="bg-secondary rounded-md text-sm">
+    <Table className="bg-card rounded-md text-sm">
       <TableHeader>
         <TableRow>
           <TableHead>Nombre</TableHead>

--- a/src/components/RightSidebar.jsx
+++ b/src/components/RightSidebar.jsx
@@ -24,7 +24,7 @@ export default function RightSidebar({
   return (
     <aside
       className={cn(
-        "w-64 bg-secondary shadow-md p-6 space-y-4 flex flex-col items-start rounded-lg self-start sticky top-[104px] h-[calc(100vh-6.5rem)]",
+        "w-64 bg-card shadow-md p-6 space-y-4 flex flex-col items-start rounded-lg self-start sticky top-[104px] h-[calc(100vh-6.5rem)]",
         className
       )}
     >


### PR DESCRIPTION
## Summary
- adjust mention card styles for unified background
- unify right sidebar, reports, and keywords tables colors

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68925a5b0cbc832b84f642e330998a67