### PR TITLE
Improve report toggle and dashboard filters

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,7 @@ import {
   Star,
   Bell,
   Plus,
+  Minus,
   TrendingUp,
   Activity,
   MessageSquare,
@@ -784,7 +785,7 @@ export default function ModernSocialListeningApp({ onLogout }) {
               </div>
 
               {/* Filters */}
-              <div className="flex flex-wrap gap-4 mb-8 p-6 bg-slate-800/30 backdrop-blur-sm border border-slate-700/50 rounded-xl">
+              <div className="relative z-10 flex flex-wrap gap-4 mb-8 p-6 bg-slate-800/30 backdrop-blur-sm border border-slate-700/50 rounded-xl">
                 <div>
                   <p className="text-sm font-medium mb-2 text-slate-300">Palabras clave</p>
                   <MultiSelect
@@ -895,7 +896,11 @@ export default function ModernSocialListeningApp({ onLogout }) {
                 onClick={() => setShowReportForm(!showReportForm)}
                 className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700"
               >
-                <Plus className="w-4 h-4 mr-2" />
+                {showReportForm ? (
+                  <Minus className="w-4 h-4 mr-2" />
+                ) : (
+                  <Plus className="w-4 h-4 mr-2" />
+                )}
                 Crear nuevo reporte
               </Button>
 

--- a/src/components/RightSidebar.jsx
+++ b/src/components/RightSidebar.jsx
@@ -101,11 +101,10 @@ export default function RightSidebar({
       <div className="border-t border-border/50 w-full" />
 
       <Button
-        variant="outline"
         onClick={handleClearFilters}
-        className="mt-auto self-center"
+        className="mt-auto self-center bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700"
       >
-        <FilterX className="size-4" />
+        <FilterX className="w-4 h-4 mr-2" />
         Limpiar filtros
       </Button>
     </aside>


### PR DESCRIPTION
## Summary
- Toggle new report form with plus/minus icon
- Style clear filters button to match gradient actions
- Ensure dashboard filters dropdown appear above charts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689267642888832b8dc9ac81760ee7ae