### PR TITLE
Replace sentiment filters with qualitative tag filters

### DIFF
--- a/src/components/MentionCard.jsx
+++ b/src/components/MentionCard.jsx
@@ -94,9 +94,9 @@ export default function MentionCard({
   };
 
   const tagTexts = {
-    approval: ["Muy valorado", "Gran aprobación"],
-    reach: ["Muchas visualizaciones", "Gran alcance"],
-    conversation: ["Muchos comentarios", "Generó conversación"],
+    approval: "Muy valorado",
+    reach: "Gran alcance",
+    conversation: "Generó conversación",
   };
 
   const tagClasses = {
@@ -128,19 +128,15 @@ export default function MentionCard({
 
     return (
       <div className="flex items-center gap-2 mt-1 flex-wrap">
-        {tags.map((type, i) => {
-          const textOptions = tagTexts[type];
-          const text = textOptions[Math.floor(Math.random() * textOptions.length)];
-          return (
-            <Badge
-              key={i}
-              variant="secondary"
-              className={`${tagClasses[type]} rounded-lg px-3 py-1 text-sm font-semibold`}
-            >
-              {text}
-            </Badge>
-          );
-        })}
+        {tags.map((type, i) => (
+          <Badge
+            key={i}
+            variant="secondary"
+            className={`${tagClasses[type]} rounded-lg px-3 py-1 text-sm font-semibold`}
+          >
+            {tagTexts[type]}
+          </Badge>
+        ))}
       </div>
     );
   };

--- a/src/components/RightSidebar.jsx
+++ b/src/components/RightSidebar.jsx
@@ -14,6 +14,8 @@ export default function RightSidebar({
   keywords,
   setKeywords,
   keywordOptions = [],
+  tags = [],
+  toggleTag,
   clearFilters,
 }) {
 
@@ -81,20 +83,22 @@ export default function RightSidebar({
       <div className="border-t border-border/50 w-full" />
 
       <div>
-        <p className="font-semibold mb-2">Sentimiento</p>
+        <p className="font-semibold mb-2">Etiquetas</p>
         <div className="space-y-2">
-          <label htmlFor="negativo" className="flex items-center gap-2 text-red-500">
-            <Checkbox id="negativo" />
-            <span>Negativo</span>
-          </label>
-          <label htmlFor="neutro" className="flex items-center gap-2 text-gray-300">
-            <Checkbox id="neutro" />
-            <span>Neutro</span>
-          </label>
-          <label htmlFor="positivo" className="flex items-center gap-2 text-green-500">
-            <Checkbox id="positivo" />
-            <span>Positivo</span>
-          </label>
+          {[
+            { id: "approval", label: "Muy valorado" },
+            { id: "reach", label: "Gran alcance" },
+            { id: "conversation", label: "Generó conversación" },
+          ].map((t) => (
+            <label key={t.id} htmlFor={t.id} className="flex items-center gap-2">
+              <Checkbox
+                id={t.id}
+                checked={tags.includes(t.id)}
+                onCheckedChange={() => toggleTag(t.id)}
+              />
+              <span>{t.label}</span>
+            </label>
+          ))}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Replace right sidebar sentiment checkboxes with tag filters for "Muy valorado", "Gran alcance" and "Generó conversación"
- Compute mention tags based on platform metrics and add filtering state in main app
- Display stable qualitative tag labels on mention cards

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f7e769ea0832bac2ef499db4d839e