### PR TITLE
Fix clear filters button layout in sidebar

### DIFF
--- a/src/components/RightSidebar.jsx
+++ b/src/components/RightSidebar.jsx
@@ -113,15 +113,17 @@ export default function RightSidebar({
         </div>
       </div>
 
-      <div className="border-t border-border/50 w-full" />
+      <div className="mt-auto w-full flex flex-col">
+        <div className="border-t border-border/50 w-full" />
 
-      <Button
-        onClick={handleClearFilters}
-        className="mt-auto self-center bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700"
-      >
-        <FilterX className="w-4 h-4 mr-2" />
-        Limpiar filtros
-      </Button>
+        <Button
+          onClick={handleClearFilters}
+          className="mt-4 w-full bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700"
+        >
+          <FilterX className="w-4 h-4 mr-2" />
+          Limpiar filtros
+        </Button>
+      </div>
     </aside>
   );
 }


### PR DESCRIPTION
## Summary
- ensure clear filters button stays inside right sidebar container

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fa059b764832ba2550250406320dc