### PR TITLE
Show top comments on mention click

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -194,7 +194,7 @@ export default function ModernSocialListeningApp({ onLogout }) {
   const fetchMentions = async () => {
     const { data, error } = await supabase
       .from("total_mentions_vw")
-      .select("*")
+      .select("*, comments:top_3_comments_vw(likes, comment)")
       .order("created_at", { ascending: false })
     if (error) {
       console.error("Error fetching mentions", error)

--- a/src/components/MentionCard.jsx
+++ b/src/components/MentionCard.jsx
@@ -46,6 +46,7 @@ export default function MentionCard({
   const [optionsOpen, setOptionsOpen] = useState(false);
   const { toggleFavorite, isFavorite } = useFavorites();
   const favorite = isFavorite(mention);
+  const comments = mention?.comments || [];
 
   const handleFavClick = (e) => {
     e.stopPropagation();
@@ -211,6 +212,22 @@ export default function MentionCard({
 
           {renderTags()}
           {expanded && renderMetrics()}
+          {expanded && comments.length > 0 && (
+            <div className="mt-4 space-y-2">
+              {comments.map((c, i) => {
+                const CommentIcon = platform === "reddit" ? ArrowBigUp : Heart
+                return (
+                  <div key={i} className="flex items-center justify-between text-sm text-muted-foreground">
+                    <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap pr-2">{c.comment}</span>
+                    <span className="flex items-center gap-1 shrink-0">
+                      <CommentIcon className="size-4" />
+                      {c.likes}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+          )}
 
           {expanded && url && (
             <div className="mt-2 text-sm">


### PR DESCRIPTION
## Summary
- fetch comment data for each mention by joining `total_mentions_vw` with `top_3_comments_vw`
- display top three liked comments when a mention card is expanded

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a243a903c4832b996d541e26d73fcc