### PR TITLE
Add 60-day range filter and shorten report names

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -50,7 +50,7 @@ export default function ModernSocialListeningApp({ onLogout }) {
   const [mentions, setMentions] = useState([])
   const [mentionsLoading, setMentionsLoading] = useState(true)
   const [menuOpen, setMenuOpen] = useState(false)
-  const [rangeFilter, setRangeFilter] = useState("")
+  const [rangeFilter, setRangeFilter] = useState("7")
   const [sourcesFilter, setSourcesFilter] = useState([])
   const [keywordsFilter, setKeywordsFilter] = useState(["all"])
   const [tagsFilter, setTagsFilter] = useState([])
@@ -446,7 +446,7 @@ export default function ModernSocialListeningApp({ onLogout }) {
   }
 
   const clearSidebarFilters = () => {
-    setRangeFilter("")
+    setRangeFilter("7")
     setSourcesFilter([])
     setSearch("")
     setKeywordsFilter(["all"])

--- a/src/components/ReportsTable.jsx
+++ b/src/components/ReportsTable.jsx
@@ -18,7 +18,11 @@ export default function ReportsTable({ reports = [], onDownload, onDelete }) {
       <TableBody>
         {reports.map((r, idx) => (
           <TableRow key={idx}>
-            <TableCell className="font-medium">{r.name}</TableCell>
+            <TableCell>
+              <div className="font-medium max-w-[200px] truncate" title={r.name}>
+                {r.name}
+              </div>
+            </TableCell>
             <TableCell>
               {r.platform
                 ? r.platform.charAt(0).toUpperCase() + r.platform.slice(1)

--- a/src/components/RightSidebar.jsx
+++ b/src/components/RightSidebar.jsx
@@ -49,6 +49,7 @@ export default function RightSidebar({
               <SelectItem value="7">Últimos 7 días</SelectItem>
               <SelectItem value="15">Últimos 15 días</SelectItem>
               <SelectItem value="30">Últimos 30 días</SelectItem>
+              <SelectItem value="60">Últimos 60 días</SelectItem>
             </SelectContent>
           </Select>
         </div>


### PR DESCRIPTION
## Summary
- extend time filter with 60-day option and default to last 7 days
- reset filters to 7-day range
- truncate long report names with ellipsis and tooltip

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a25d8d25f0832bb94ac95e7785e6ba