### PR TITLE
feat: add onboarding flow

### DIFF
--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -19,7 +19,7 @@ export default function Login() {
     if (error) {
       setError(error.message)
     } else {
-      navigate("/home")
+      navigate("/app/mentions")
     }
   };
 

--- a/src/OnboardingHome.jsx
+++ b/src/OnboardingHome.jsx
@@ -1,0 +1,98 @@
+import { useState } from 'react'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { supabase } from '@/lib/supabaseClient'
+import { useAuth } from '@/context/AuthContext'
+import { useNavigate } from 'react-router-dom'
+
+export default function OnboardingHome() {
+  const [keywords, setKeywords] = useState([])
+  const [newKeyword, setNewKeyword] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+  const { user } = useAuth()
+  const navigate = useNavigate()
+
+  const addKeyword = () => {
+    const kw = newKeyword.trim()
+    if (kw && !keywords.includes(kw)) {
+      setKeywords([...keywords, kw])
+      setNewKeyword('')
+    }
+  }
+
+  const removeKeyword = (kw) => {
+    setKeywords(keywords.filter((k) => k !== kw))
+  }
+
+  const saveKeywords = async () => {
+    if (!keywords.length) return
+    setSaving(true)
+    const rows = keywords.map((k) => ({
+      keyword: k,
+      user_id: user.id,
+      created_at: new Date().toISOString(),
+      active: true,
+    }))
+    const { error } = await supabase.from('dim_keywords').insert(rows)
+    setSaving(false)
+    if (!error) {
+      setSaved(true)
+    } else {
+      console.error('Error saving keywords', error)
+    }
+  }
+
+  return (
+    <div className="max-w-xl mx-auto mt-10 p-4 flex flex-col gap-6">
+      <h1 className="text-2xl font-bold">Bienvenido a Social Listening</h1>
+      <p className="text-muted-foreground">
+        Descubre qué se dice sobre tu marca en las redes sociales.
+      </p>
+      <ol className="list-decimal list-inside space-y-1">
+        <li>Carga tus keywords</li>
+        <li>Revisa las menciones</li>
+        <li>Recibe alertas</li>
+      </ol>
+      <div className="flex gap-2">
+        <Input
+          value={newKeyword}
+          onChange={(e) => setNewKeyword(e.target.value)}
+          placeholder="Nueva keyword"
+        />
+        <Button type="button" onClick={addKeyword}>
+          Agregar
+        </Button>
+      </div>
+      {keywords.length > 0 && (
+        <ul className="list-disc list-inside space-y-1">
+          {keywords.map((kw) => (
+            <li key={kw} className="flex items-center justify-between">
+              <span>{kw}</span>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => removeKeyword(kw)}
+              >
+                Eliminar
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {!saved ? (
+        <Button
+          type="button"
+          onClick={saveKeywords}
+          disabled={saving || keywords.length === 0}
+        >
+          Guardar y continuar
+        </Button>
+      ) : (
+        <Button type="button" onClick={() => navigate('/app/mentions')}>
+          Ir al inicio
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/src/ProtectedRoute.jsx
+++ b/src/ProtectedRoute.jsx
@@ -1,11 +1,44 @@
-import { Navigate } from 'react-router-dom'
+import { Navigate, useLocation } from 'react-router-dom'
 import { useAuth } from '@/context/AuthContext'
+import { useEffect, useState } from 'react'
+import { supabase } from '@/lib/supabaseClient'
 
 export default function ProtectedRoute({ children }) {
   const { session, loading } = useAuth()
+  const location = useLocation()
+  const [checkingKeywords, setCheckingKeywords] = useState(true)
+  const [hasKeywords, setHasKeywords] = useState(false)
 
-  if (loading) return null
+  useEffect(() => {
+    const checkKeywords = async () => {
+      if (!session) {
+        setCheckingKeywords(false)
+        setHasKeywords(false)
+        return
+      }
+
+      const { count, error } = await supabase
+        .from('dim_keywords')
+        .select('keyword_id', { count: 'exact', head: true })
+      if (error) {
+        console.error('Error checking keywords', error)
+      }
+      setHasKeywords((count ?? 0) > 0)
+      setCheckingKeywords(false)
+    }
+    checkKeywords()
+  }, [session, location.pathname])
+
+  if (loading || checkingKeywords) return null
   if (!session) return <Navigate to="/login" replace />
+
+  if (!hasKeywords && location.pathname !== '/onboarding') {
+    return <Navigate to="/onboarding" replace />
+  }
+
+  if (hasKeywords && location.pathname === '/onboarding') {
+    return <Navigate to="/app/mentions" replace />
+  }
 
   return children
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,7 @@ import { FavoritesProvider } from './context/FavoritesContext'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import ProtectedRoute from './ProtectedRoute'
 import { AuthProvider, useAuth } from './context/AuthContext'
+import OnboardingHome from './OnboardingHome'
 
 function Root() {
   const { session, loading } = useAuth()
@@ -20,14 +21,14 @@ function Root() {
         <Routes>
           <Route
             path="/login"
-            element={session ? <Navigate to="/home" replace /> : <Login />}
+            element={session ? <Navigate to="/app/mentions" replace /> : <Login />}
           />
           <Route
             path="/register"
-            element={session ? <Navigate to="/home" replace /> : <Register />}
+            element={session ? <Navigate to="/app/mentions" replace /> : <Register />}
           />
           <Route
-            path="/home"
+            path="/app/mentions"
             element={
               <ProtectedRoute>
                 <SocialListeningApp />
@@ -35,8 +36,16 @@ function Root() {
             }
           />
           <Route
+            path="/onboarding"
+            element={
+              <ProtectedRoute>
+                <OnboardingHome />
+              </ProtectedRoute>
+            }
+          />
+          <Route
             path="*"
-            element={<Navigate to={session ? '/home' : '/login'} replace />}
+            element={<Navigate to={session ? '/app/mentions' : '/login'} replace />}
           />
         </Routes>
       </BrowserRouter>


### PR DESCRIPTION
## Summary
- add onboarding page to capture keywords
- redirect new users without keywords to onboarding
- move feed to /app/mentions route

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a66225e298832bb307f67a176dd8e0