### PR TITLE
feat: handle empty database mentions message

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -957,6 +957,12 @@ export default function ModernSocialListeningApp({ onLogout }) {
                           />
                         </div>
                       ))
+                    ) : mentions.length === 0 ? (
+                      <div className="text-center py-12">
+                        <MessageSquare className="w-12 h-12 text-slate-600 mx-auto mb-4" />
+                        <p className="text-slate-400 text-lg">Estamos recolectando menciones...</p>
+                        <p className="text-slate-500 text-sm">Aparecerán aquí en breve.</p>
+                      </div>
                     ) : (
                       <div className="text-center py-12">
                         <MessageSquare className="w-12 h-12 text-slate-600 mx-auto mb-4" />


### PR DESCRIPTION
## Summary
- show a collecting message when user has no mentions in database
- retain existing no-results message when filters yield no mentions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7d14f2a30832bb31d029dd16adac6