### PR TITLE
feat: update help menu icons and allow marking mentions irrelevant

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,6 +32,8 @@ import {
   ChevronDown,
   Sparkles,
   LogOut,
+  Lightbulb,
+  Headset,
 } from "lucide-react"
 import { useFavorites } from "@/context/FavoritesContext"
 import { formatDistanceToNow, parseISO } from "date-fns"
@@ -789,14 +791,16 @@ export default function ModernSocialListeningApp({ onLogout }) {
                 <div className="absolute right-0 top-12 bg-slate-800/95 backdrop-blur-xl border border-slate-700/50 shadow-xl rounded-lg p-2 space-y-1 z-50 min-w-[180px]">
                   <button
                     onClick={() => setHelpMenuOpen(false)}
-                    className="w-full text-left p-3 rounded-md hover:bg-slate-700/50 text-slate-300 hover:text-white transition-colors"
+                    className="flex items-center gap-3 w-full text-left p-3 rounded-md hover:bg-slate-700/50 text-slate-300 hover:text-white transition-colors"
                   >
+                    <Headset className="w-4 h-4" />
                     Solicitar soporte
                   </button>
                   <button
                     onClick={() => setHelpMenuOpen(false)}
-                    className="w-full text-left p-3 rounded-md hover:bg-slate-700/50 text-slate-300 hover:text-white transition-colors"
+                    className="flex items-center gap-3 w-full text-left p-3 rounded-md hover:bg-slate-700/50 text-slate-300 hover:text-white transition-colors"
                   >
+                    <Lightbulb className="w-4 h-4" />
                     Brindar feedback
                   </button>
                 </div>

--- a/src/components/MentionCard.jsx
+++ b/src/components/MentionCard.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { supabase } from "@/lib/supabaseClient";
 import {
   FaTwitter,
   FaYoutube,
@@ -165,10 +166,22 @@ export default function MentionCard({
         <div className="absolute right-2 top-8 bg-card shadow-md rounded p-2 space-y-1 z-50">
           {showDismiss && (
             <button
-              onClick={(e) => {
+              onClick={async (e) => {
                 e.stopPropagation();
                 setOptionsOpen(false);
-                if (onHide) onHide();
+                const confirmed = window.confirm(
+                  "¿Estás seguro de que deseas marcar esta mención como irrelevante? Las menciones irrelevantes ya no se mostrarán."
+                );
+                if (!confirmed) return;
+                try {
+                  await supabase
+                    .from("fact_mentions")
+                    .update({ is_relevant: false })
+                    .eq("content_id", mention.content_id);
+                  if (onHide) onHide();
+                } catch (error) {
+                  console.error("Error updating mention relevance", error);
+                }
               }}
               className="flex items-center gap-2 w-full text-left p-2 rounded hover:bg-muted"
             >


### PR DESCRIPTION
## Summary
- add headset and lightbulb icons to help menu options
- allow marking a mention as irrelevant and update Supabase

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Rollup failed to resolve import "framer-motion")


------
https://chatgpt.com/codex/tasks/task_e_68a9143d0014832b91290466fc6a2a12