### PR TITLE
Handle is_highlighted consistently as boolean

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -194,15 +194,19 @@ export default function ModernSocialListeningApp({ onLogout }) {
 
   const visibleMentions = sortedMentions.filter((m) => !hiddenMentions.includes(m.url))
   const homeMentions = onlyFavorites
-    ? visibleMentions.filter((m) => m.is_highlighted)
+    ? visibleMentions.filter(
+        (m) => m.is_highlighted === true || m.is_highlighted === "true",
+      )
     : visibleMentions
 
   const toggleHighlight = async (mention) => {
-    const newValue = !mention.is_highlighted
+    const currentHighlight =
+      mention.is_highlighted === true || mention.is_highlighted === "true"
+    const newValue = !currentHighlight
     try {
       const { error } = await supabase
         .from("fact_mentions")
-        .update({ is_highlighted: newValue })
+        .update({ is_highlighted: !!newValue })
         .eq("content_id", mention.content_id)
       if (error) throw error
       setMentions((prev) =>
@@ -273,6 +277,7 @@ export default function ModernSocialListeningApp({ onLogout }) {
     // 3) Uno resultados sin pisar la métrica numérica `comments`
     const enriched = rows.map((r) => ({
       ...r,
+      is_highlighted: r.is_highlighted === true || r.is_highlighted === "true",
       top_comments: topCommentsById[r.content_id] || [],
     }))
 

--- a/src/components/MentionCard.jsx
+++ b/src/components/MentionCard.jsx
@@ -45,7 +45,8 @@ export default function MentionCard({
 
   const [expanded, setExpanded] = useState(false);
   const [optionsOpen, setOptionsOpen] = useState(false);
-  const favorite = mention.is_highlighted;
+  const favorite =
+    mention.is_highlighted === true || mention.is_highlighted === "true";
 
   // ✅ top 3 comentarios vienen como array en mention.top_comments
   const topComments = Array.isArray(mention?.top_comments) ? mention.top_comments : [];


### PR DESCRIPTION
## Summary
- Explicitly check boolean truth when filtering favorites
- Coerce and persist is_highlighted as boolean across Supabase updates
- Interpret is_highlighted consistently in MentionCard UI

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a9389727e4832b88bb44f4da1965c7