### PR TITLE
Fix dashboard tooltip and convert comment tooltips to HTML titles

### DIFF
--- a/src/components/MentionCard.jsx
+++ b/src/components/MentionCard.jsx
@@ -256,16 +256,12 @@ export default function MentionCard({
                       {/* Contenedor del texto: puede encogerse (truco w-0 flex-1) */}
                       <div className="w-0 flex-1 max-w-full" style={{ minWidth: 0 }}>
                         {/* Texto: una sola línea con “…” (funciona incluso en flex) */}
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <span className="block overflow-hidden text-ellipsis whitespace-nowrap">
-                              {c.comment ?? "—"}
-                            </span>
-                          </TooltipTrigger>
-                          {c.comment && (
-                            <TooltipContent>{c.comment}</TooltipContent>
-                          )}
-                        </Tooltip>
+                        <span
+                          className="block overflow-hidden text-ellipsis whitespace-nowrap"
+                          title={c.comment ?? undefined}
+                        >
+                          {c.comment ?? "—"}
+                        </span>
                       </div>
 
                       {/* Métrica: fijo, no se encoge */}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -27,10 +27,11 @@ export interface BadgeProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof badgeVariants> {}
 
-function Badge({ className, variant, ...props }: BadgeProps) {
-  return (
-    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(
+  ({ className, variant, ...props }, ref) => (
+    <div ref={ref} className={cn(badgeVariants({ variant }), className)} {...props} />
   )
-}
+)
+Badge.displayName = "Badge"
 
 export { Badge, badgeVariants }


### PR DESCRIPTION
## Summary
- use native `title` attribute for highlighted comment tooltips
- forward refs in `Badge` so dashboard tooltip renders correctly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aba17976e0832b8db2a39877fee50e