### PR TITLE
Add keyword language selection and display

### DIFF
--- a/src/OnboardingHome.jsx
+++ b/src/OnboardingHome.jsx
@@ -80,8 +80,17 @@ export default function ModernOnboardingHome() {
   const saveLanguages = async () => {
     if (!languages.length) return
     setSavingLanguages(true)
+    const { error } = await supabase
+      .from("dim_keywords")
+      .update({ language_codes: languages })
+      .eq("user_id", user.id)
+      .in("keyword", keywords)
     setSavingLanguages(false)
-    navigate("/app/mentions")
+    if (!error) {
+      navigate("/app/mentions")
+    } else {
+      console.error("Error saving languages", error)
+    }
   }
 
   const saveKeywords = async () => {

--- a/src/components/KeywordTable.jsx
+++ b/src/components/KeywordTable.jsx
@@ -14,6 +14,7 @@ export default function KeywordTable({ keywords, onToggle }) {
       <TableHeader>
         <TableRow>
           <TableHead>Keyword</TableHead>
+          <TableHead>Idioma(s)</TableHead>
           <TableHead>Fecha de creación</TableHead>
           <TableHead>Última extracción de datos</TableHead>
           <TableHead>Estado</TableHead>
@@ -36,6 +37,7 @@ export default function KeywordTable({ keywords, onToggle }) {
           return (
             <TableRow key={k.keyword_id}>
               <TableCell className="font-medium">{k.keyword}</TableCell>
+              <TableCell>{k.language_codes?.join(", ") || "-"}</TableCell>
               <TableCell>
                 {format(new Date(k.created_at), "dd/MM/yyyy", { locale: es })}
               </TableCell>


### PR DESCRIPTION
## Summary
- Save onboarding language selections to `dim_keywords.language_codes`
- Show keyword languages in configuration table
- Allow selecting languages when adding keywords

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad33fdf7c0832bb426c7d609390d6e