### PR TITLE
fix: store selected language codes

### DIFF
--- a/src/components/MultiSelect.jsx
+++ b/src/components/MultiSelect.jsx
@@ -34,8 +34,9 @@ export default function MultiSelect({ options = [], value = [], onChange, placeh
     } else {
       newVal.push(val);
     }
+    const hasAllOption = options.some((o) => o.value === "all");
     const nonAllOptions = options.filter((o) => o.value !== "all").map((o) => o.value);
-    if (newVal.length === nonAllOptions.length) {
+    if (hasAllOption && newVal.length === nonAllOptions.length) {
       newVal = ["all"];
     }
     onChange(newVal);


### PR DESCRIPTION
## Summary
- ensure MultiSelect only collapses to `all` when that option exists, preserving all selected language codes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad3a855fbc832bab6cb782a67063ab