### PR TITLE
Use comment_likes for top comment metrics

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -373,7 +373,7 @@ export default function ModernSocialListeningApp({ onLogout }) {
     try {
       const { data: tc, error: errTc } = await supabase
         .from("top_3_comments_vw")
-        .select("content_id, likes, comment")
+        .select("content_id, comment_likes, comment")
         .in("content_id", contentIds)
 
       if (errTc) {
@@ -383,14 +383,14 @@ export default function ModernSocialListeningApp({ onLogout }) {
           const k = item.content_id
           if (!k) return acc
           if (!acc[k]) acc[k] = []
-          acc[k].push({ likes: item.likes, comment: item.comment })
+          acc[k].push({ comment_likes: item.comment_likes, comment: item.comment })
           return acc
         }, {})
 
         // Aseguro top 3 por likes
         for (const k of Object.keys(topCommentsById)) {
           topCommentsById[k] = topCommentsById[k]
-            .sort((a, b) => (b.likes ?? 0) - (a.likes ?? 0))
+            .sort((a, b) => (b.comment_likes ?? 0) - (a.comment_likes ?? 0))
             .slice(0, 3)
         }
       }

--- a/src/components/MentionCard.jsx
+++ b/src/components/MentionCard.jsx
@@ -248,7 +248,7 @@ export default function MentionCard({
                       {/* Métrica: fijo, no se encoge */}
                       <span className="flex items-center gap-1 flex-none text-xs font-medium">
                         <CommentIcon className="size-4" />
-                        {c.likes ?? 0}
+                        {c.comment_likes ?? 0}
                       </span>
                     </div>
                   );


### PR DESCRIPTION
## Summary
- Fetch comment likes from `top_3_comments_vw` instead of generic likes
- Display comment like counts in mention cards

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: You installed esbuild for another platform than the one you're currently using.)*

------
https://chatgpt.com/codex/tasks/task_e_68ae33ef8914832b97ff80b6ab67802d