### PR TITLE
Switch mentions view and tighten filters

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -348,7 +348,7 @@ export default function ModernSocialListeningApp({ onLogout }) {
     setMentionsLoading(true)
     // 1) Traigo menciones base SIN joins anidados
     const { data: base, error: errBase } = await supabase
-      .from("total_mentions_vw")
+      .from("mentions_display_vw")
       .select("*")
       .order("created_at", { ascending: false })
 

--- a/src/components/RightSidebar.jsx
+++ b/src/components/RightSidebar.jsx
@@ -49,7 +49,6 @@ export default function RightSidebar({
               <SelectItem value="7">Últimos 7 días</SelectItem>
               <SelectItem value="15">Últimos 15 días</SelectItem>
               <SelectItem value="30">Últimos 30 días</SelectItem>
-              <SelectItem value="60">Últimos 60 días</SelectItem>
             </SelectContent>
           </Select>
         </div>
@@ -78,7 +77,7 @@ export default function RightSidebar({
               {[
                 { id: "youtube", label: "YouTube" },
                 { id: "reddit", label: "Reddit" },
-                { id: "twitter", label: "Twitter" },
+                { id: "twitter", label: "Twitter", disabled: true },
                 { id: "tiktok", label: "TikTok", disabled: true },
               ].map((s) => (
                 <Tooltip key={s.id}>


### PR DESCRIPTION
## Summary
- Use `mentions_display_vw` as the source for mentions
- Limit right sidebar date filter to last 7, 15, or 30 days
- Disable Twitter in source filters with matching tooltip

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae603a9d68832ba5b01ceb361292af