### PR TITLE
Add AI summary dropdown

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -44,6 +44,7 @@ import ReportsTable from "@/components/ReportsTable"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
+import AISummary from "@/components/AISummary"
 
 // ===== Helpers for time buckets and engagement metrics =====
 // Hours elapsed since a given ISO date
@@ -1333,6 +1334,7 @@ export default function ModernSocialListeningApp({ onLogout }) {
             <section className="p-8">
               <div className="flex items-start gap-8 min-h-screen">
                 <div className="flex-1">
+                  <AISummary />
                   {/* Search Header */}
                   <div className="mb-8">
                     <div className="relative mb-6">

--- a/src/components/AISummary.jsx
+++ b/src/components/AISummary.jsx
@@ -1,0 +1,25 @@
+import { useState } from "react"
+import { ChevronDown } from "lucide-react"
+
+export default function AISummary() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="mb-8">
+      <div
+        onClick={() => setOpen(!open)}
+        className="flex items-center justify-between p-4 rounded-lg bg-slate-800/50 border border-slate-700/50 shadow-sm cursor-pointer"
+      >
+        <span className="text-sm font-medium text-white">Resumen de AI</span>
+        <ChevronDown
+          className={`w-4 h-4 text-slate-400 transition-transform ${open ? "rotate-180" : ""}`}
+        />
+      </div>
+      {open && (
+        <div className="mt-2 p-4 rounded-lg bg-slate-800/50 border border-slate-700/50 shadow-sm">
+          <p className="text-sm text-slate-400">No disponible en la versión gratuita</p>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add expandable AI summary placeholder above the home search bar
- integrate dropdown panel with rotating arrow icon

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4e49d1644832b96e593943175aee9