### PR TITLE
Refactor onboarding language selection

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -171,7 +171,7 @@ export default function ModernSocialListeningApp({ onLogout }) {
   const [saveKeywordMessage, setSaveKeywordMessage] = useState(null)
   const [keywordChanges, setKeywordChanges] = useState({})
   const [showKeywordLangs, setShowKeywordLangs] = useState(false)
-  const [newKeywordLangs, setNewKeywordLangs] = useState([])
+  const [newKeywordLang, setNewKeywordLang] = useState("")
   const [pendingKeyword, setPendingKeyword] = useState("")
   const navigate = useNavigate()
   const [onlyFavorites, setOnlyFavorites] = useState(false)
@@ -476,7 +476,7 @@ export default function ModernSocialListeningApp({ onLogout }) {
     const { data, error } = await supabase
       .from("dim_keywords")
       .select(
-        "keyword, keyword_id, created_at, active, language_codes, last_processed_at_yt, last_processed_at_rd, last_processed_at_tw",
+        "keyword, keyword_id, created_at, active, language, last_processed_at_yt, last_processed_at_rd, last_processed_at_tw",
       )
       .order("created_at", { ascending: false })
     if (error) {
@@ -529,12 +529,12 @@ export default function ModernSocialListeningApp({ onLogout }) {
     if (!newKeyword.trim()) return
     setPendingKeyword(newKeyword.trim())
     setShowKeywordLangs(true)
-    setNewKeywordLangs([])
+    setNewKeywordLang("")
     setAddKeywordMessage(null)
   }
 
   const saveNewKeyword = async () => {
-    if (!pendingKeyword.trim() || newKeywordLangs.length === 0) return
+    if (!pendingKeyword.trim() || !newKeywordLang) return
     setAddKeywordMessage(null)
     const { data: userData } = await supabase.auth.getUser()
     const { user } = userData || {}
@@ -549,7 +549,7 @@ export default function ModernSocialListeningApp({ onLogout }) {
         user_id: user.id,
         created_at: new Date().toISOString(),
         active: false,
-        language_codes: newKeywordLangs,
+        language: newKeywordLang,
       })
       .select()
     if (error || !data || data.length === 0) {
@@ -562,7 +562,7 @@ export default function ModernSocialListeningApp({ onLogout }) {
       setKeywords((k) => [...data, ...k])
       setNewKeyword("")
       setPendingKeyword("")
-      setNewKeywordLangs([])
+      setNewKeywordLang("")
       setShowKeywordLangs(false)
       setAddKeywordMessage({ type: "success", text: "Keyword agregada" })
     }
@@ -1921,16 +1921,19 @@ export default function ModernSocialListeningApp({ onLogout }) {
                     </div>
                     {showKeywordLangs && (
                       <div className="flex items-center gap-3 mt-4">
-                        <MultiSelect
-                          options={[{ label: "Español", value: "es" }, { label: "Inglés", value: "en" }]}
-                          value={newKeywordLangs}
-                          onChange={setNewKeywordLangs}
-                          placeholder="Selecciona idiomas"
-                          className="flex-1"
-                        />
+                        <Select value={newKeywordLang} onValueChange={setNewKeywordLang}>
+                          <SelectTrigger className="flex-1">
+                            <SelectValue placeholder="Selecciona un idioma" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="all">Todos</SelectItem>
+                            <SelectItem value="es">Español</SelectItem>
+                            <SelectItem value="en">Inglés</SelectItem>
+                          </SelectContent>
+                        </Select>
                         <Button
                           onClick={saveNewKeyword}
-                          disabled={newKeywordLangs.length === 0}
+                          disabled={!newKeywordLang}
                           className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 disabled:opacity-50"
                         >
                           Guardar
@@ -1939,7 +1942,7 @@ export default function ModernSocialListeningApp({ onLogout }) {
                           variant="outline"
                           onClick={() => {
                             setShowKeywordLangs(false)
-                            setNewKeywordLangs([])
+                            setNewKeywordLang("")
                           }}
                           className="border-slate-700/50 text-slate-300 hover:text-white hover:bg-slate-700/50 bg-transparent"
                         >

--- a/src/OnboardingHome.jsx
+++ b/src/OnboardingHome.jsx
@@ -7,7 +7,13 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select"
 import { supabase } from "@/lib/supabaseClient"
 import { useAuth } from "@/context/AuthContext"
 import { useNavigate } from "react-router-dom"
@@ -40,8 +46,8 @@ export default function ModernOnboardingHome() {
   const [saved, setSaved] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
   const [step, setStep] = useState(0)
-  const [languages, setLanguages] = useState([])
-  const [savingLanguages, setSavingLanguages] = useState(false)
+  const [language, setLanguage] = useState("")
+  const [savingLanguage, setSavingLanguage] = useState(false)
   const { user } = useAuth()
   const navigate = useNavigate()
 
@@ -71,25 +77,20 @@ export default function ModernOnboardingHome() {
     setKeywords(keywords.filter((k) => k !== kw))
   }
 
-  const toggleLanguage = (lang) => {
-    setLanguages((prev) =>
-      prev.includes(lang) ? prev.filter((l) => l !== lang) : [...prev, lang]
-    )
-  }
 
-  const saveLanguages = async () => {
-    if (!languages.length) return
-    setSavingLanguages(true)
+  const saveLanguage = async () => {
+    if (!language) return
+    setSavingLanguage(true)
     const { error } = await supabase
       .from("dim_keywords")
-      .update({ language_codes: languages })
+      .update({ language })
       .eq("user_id", user.id)
       .in("keyword", keywords)
-    setSavingLanguages(false)
+    setSavingLanguage(false)
     if (!error) {
       navigate("/app/mentions")
     } else {
-      console.error("Error saving languages", error)
+      console.error("Error saving language", error)
     }
   }
 
@@ -349,7 +350,7 @@ export default function ModernOnboardingHome() {
           )}
           {step === 2 && (
             <motion.div
-              key="languages"
+              key="language"
               initial={{ x: 100, opacity: 0 }}
               animate={{ x: 0, opacity: 1 }}
               exit={{ x: -100, opacity: 0 }}
@@ -359,30 +360,30 @@ export default function ModernOnboardingHome() {
               <Card className="bg-slate-800/30 backdrop-blur-sm border-slate-700/50">
                 <CardContent className="p-8">
                   <div className="mb-8">
-                    <h2 className="text-2xl font-semibold text-white mb-2">Selecciona los idiomas</h2>
-                    <p className="text-slate-400">Elige los idiomas en los que deseas monitorear las menciones.</p>
+                    <h2 className="text-2xl font-semibold text-white mb-2">Selecciona el idioma</h2>
+                    <p className="text-slate-400">Elige el idioma en el que deseas monitorear las menciones o selecciona "Todos".</p>
                   </div>
 
-                  <div className="space-y-4 mb-8">
-                    {[{ id: "es", label: "Español" }, { id: "en", label: "Inglés" }].map((lang) => (
-                      <label key={lang.id} htmlFor={lang.id} className="flex items-center gap-2">
-                        <Checkbox
-                          id={lang.id}
-                          checked={languages.includes(lang.id)}
-                          onCheckedChange={() => toggleLanguage(lang.id)}
-                        />
-                        <span className="text-white">{lang.label}</span>
-                      </label>
-                    ))}
+                  <div className="mb-8">
+                    <Select value={language} onValueChange={setLanguage}>
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder="Selecciona un idioma" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all">Todos</SelectItem>
+                        <SelectItem value="es">Español</SelectItem>
+                        <SelectItem value="en">Inglés</SelectItem>
+                      </SelectContent>
+                    </Select>
                   </div>
 
                   <div className="flex flex-col sm:flex-row gap-4">
                     <Button
-                      onClick={saveLanguages}
-                      disabled={savingLanguages || languages.length === 0}
+                      onClick={saveLanguage}
+                      disabled={savingLanguage || !language}
                       className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 disabled:opacity-50 h-12 flex-1"
                     >
-                      {savingLanguages ? (
+                      {savingLanguage ? (
                         <>
                           <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin mr-2" />
                           Guardando...
@@ -395,14 +396,6 @@ export default function ModernOnboardingHome() {
                       )}
                     </Button>
                   </div>
-
-                  {languages.length === 0 && (
-                    <div className="mt-6 p-4 bg-slate-700/30 border border-slate-600/30 rounded-lg">
-                      <p className="text-sm text-slate-400 text-center">
-                        💡 <strong>Tip:</strong> Puedes seleccionar más de un idioma.
-                      </p>
-                    </div>
-                  )}
                 </CardContent>
               </Card>
 

--- a/src/components/KeywordTable.jsx
+++ b/src/components/KeywordTable.jsx
@@ -14,7 +14,7 @@ export default function KeywordTable({ keywords, onToggle }) {
       <TableHeader>
         <TableRow>
           <TableHead>Keyword</TableHead>
-          <TableHead>Idioma(s)</TableHead>
+          <TableHead>Idioma</TableHead>
           <TableHead>Fecha de creación</TableHead>
           <TableHead>Última extracción de datos</TableHead>
           <TableHead>Estado</TableHead>
@@ -37,7 +37,7 @@ export default function KeywordTable({ keywords, onToggle }) {
           return (
             <TableRow key={k.keyword_id}>
               <TableCell className="font-medium">{k.keyword}</TableCell>
-              <TableCell>{k.language_codes?.join(", ") || "-"}</TableCell>
+              <TableCell>{k.language || "-"}</TableCell>
               <TableCell>
                 {format(new Date(k.created_at), "dd/MM/yyyy", { locale: es })}
               </TableCell>


### PR DESCRIPTION
## Summary
- Use new `language` column instead of `language_codes`
- Switch onboarding to single language select with 'Todos'
- Save new keyword language as a single code

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b734f9c22c832b8f1a9cff66367eca