### PR TITLE
Remove time filter from sidebar and move original post button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -157,7 +157,6 @@ export default function ModernSocialListeningApp({ onLogout }) {
   const loadedMentionIdsRef = useRef(new Set())
   const [menuOpen, setMenuOpen] = useState(false)
   const [helpMenuOpen, setHelpMenuOpen] = useState(false)
-  const [rangeFilter, setRangeFilter] = useState("7")
   const [sourcesFilter, setSourcesFilter] = useState([])
   const [keywordsFilter, setKeywordsFilter] = useState(["all"])
   const [tagsFilter, setTagsFilter] = useState([])
@@ -299,16 +298,6 @@ export default function ModernSocialListeningApp({ onLogout }) {
 
     const matchesSource = sourcesFilter.length === 0 || sourcesFilter.includes(m.platform?.toLowerCase())
 
-    const matchesRange =
-      !rangeFilter ||
-      (() => {
-        const days = Number.parseInt(rangeFilter, 10)
-        const created = new Date(m.created_at)
-        const now = new Date()
-        const diff = (now.getTime() - created.getTime()) / (1000 * 60 * 60 * 24)
-        return diff <= days
-      })()
-
     const matchesKeyword = keywordsFilter.includes("all") || keywordsFilter.includes(m.keyword)
     const mentionTags = getTagsForMention(m)
     const matchesTag = tagsFilter.length === 0 || tagsFilter.some((t) => mentionTags.includes(t))
@@ -318,7 +307,6 @@ export default function ModernSocialListeningApp({ onLogout }) {
     return (
       matchesSearch &&
       matchesSource &&
-      matchesRange &&
       matchesKeyword &&
       matchesTag &&
       matchesAiTag
@@ -721,7 +709,6 @@ export default function ModernSocialListeningApp({ onLogout }) {
   }
 
   const clearSidebarFilters = () => {
-    setRangeFilter("7")
     setSourcesFilter([])
     setSearch("")
     setKeywordsFilter(["all"])
@@ -1477,8 +1464,6 @@ export default function ModernSocialListeningApp({ onLogout }) {
 
                 <RightSidebar
                   className="mt-0 ml-auto"
-                  range={rangeFilter}
-                  setRange={setRangeFilter}
                   sources={sourcesFilter}
                   toggleSource={toggleSourceFilter}
                   keywords={keywordsFilter}

--- a/src/components/MentionCard.jsx
+++ b/src/components/MentionCard.jsx
@@ -475,6 +475,22 @@ export default function ModernMentionCard({
               {/* Metrics */}
               {expanded && renderMetrics()}
 
+              {/* Action Button */}
+              {expanded && url && (
+                <div className="mt-6 pt-4 border-t border-slate-700/50">
+                  <Button
+                    size="sm"
+                    asChild
+                    onClick={(e) => e.stopPropagation()}
+                    className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700"
+                  >
+                    <a href={url} target="_blank" rel="noopener noreferrer">
+                      Ver publicación original
+                    </a>
+                  </Button>
+                </div>
+              )}
+
               {/* Sentiment Analysis - Only for YouTube and Reddit */}
               {expanded && renderSentimentAnalysis()}
 
@@ -519,22 +535,6 @@ export default function ModernMentionCard({
                       )
                     })}
                   </div>
-                </div>
-              )}
-
-              {/* Action Button */}
-              {expanded && url && (
-                <div className="mt-6 pt-4 border-t border-slate-700/50">
-                  <Button
-                    size="sm"
-                    asChild
-                    onClick={(e) => e.stopPropagation()}
-                    className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700"
-                  >
-                    <a href={url} target="_blank" rel="noopener noreferrer">
-                      Ver publicación original
-                    </a>
-                  </Button>
                 </div>
               )}
             </div>

--- a/src/components/RightSidebar.jsx
+++ b/src/components/RightSidebar.jsx
@@ -1,18 +1,15 @@
 "use client"
 
-import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip"
-import { FilterX, Sparkles, TrendingUp, Users, MessageSquare, Clock, Hash, Globe, Tag, Zap } from "lucide-react"
+import { FilterX, Sparkles, TrendingUp, Users, MessageSquare, Hash, Globe, Tag, Zap } from "lucide-react"
 import { cn } from "@/lib/utils"
 import MultiSelect from "@/components/MultiSelect"
 
 export default function RightSidebar({
   className = "",
-  range,
-  setRange,
   sources,
   toggleSource,
   keywords,
@@ -69,30 +66,6 @@ export default function RightSidebar({
 
         {/* Content */}
         <div className="flex-1 p-6 space-y-8 overflow-y-auto">
-          {/* Time Range */}
-          <div className="space-y-4">
-            <div className="flex items-center gap-2">
-              <Clock className="w-4 h-4 text-slate-400" />
-              <h4 className="font-medium text-white">Rango de tiempo</h4>
-            </div>
-            <Select value={range} onValueChange={setRange}>
-              <SelectTrigger className="w-full bg-slate-800/50 border-slate-700/50 text-white focus:border-blue-500/50 focus:ring-blue-500/20">
-                <SelectValue placeholder="Seleccionar período" />
-              </SelectTrigger>
-              <SelectContent className="bg-slate-800/95 backdrop-blur-xl border-slate-700/50">
-                <SelectItem value="7" className="text-slate-300 focus:bg-slate-700/50 focus:text-white">
-                  Últimos 7 días
-                </SelectItem>
-                <SelectItem value="15" className="text-slate-300 focus:bg-slate-700/50 focus:text-white">
-                  Últimos 15 días
-                </SelectItem>
-                <SelectItem value="30" className="text-slate-300 focus:bg-slate-700/50 focus:text-white">
-                  Últimos 30 días
-                </SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
           {/* Keywords */}
           <div className="space-y-4">
             <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- remove the time range filter from the right sidebar and its state in the main app
- adjust mention filtering and clear filters logic to no longer depend on the removed control
- place the "Ver publicación original" button above the sentiment analysis section inside each mention card

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8843ced60832b97f456af23399481