### PR TITLE
feat: gate premium features by subscription plan

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -183,6 +183,8 @@ export default function ModernSocialListeningApp({ onLogout }) {
   const [showPasswordFields, setShowPasswordFields] = useState(false)
   const [currentPassword, setCurrentPassword] = useState("")
   const [newPassword, setNewPassword] = useState("")
+  const [userPlan, setUserPlan] = useState("free")
+  const isFreePlan = userPlan === "free"
   const [reportStartDate, setReportStartDate] = useState("")
   const [reportEndDate, setReportEndDate] = useState("")
   const [reportPlatform, setReportPlatform] = useState("")
@@ -576,6 +578,10 @@ export default function ModernSocialListeningApp({ onLogout }) {
       setAccountEmail(user.email || "")
       setAccountName(displayName)
       setOriginalAccountName(displayName)
+      const plan = user.user_metadata?.plan || user.app_metadata?.plan || "free"
+      setUserPlan(plan)
+    } else {
+      setUserPlan("free")
     }
   }
 
@@ -1349,7 +1355,7 @@ export default function ModernSocialListeningApp({ onLogout }) {
             <section className="p-8">
               <div className="flex items-start gap-8 min-h-screen">
                 <div className="flex-1">
-                  <AISummary />
+                  <AISummary isFreePlan={isFreePlan} />
                   {/* Search Header */}
                   <div className="mb-8">
                     <div className="relative mb-6">
@@ -1436,6 +1442,7 @@ export default function ModernSocialListeningApp({ onLogout }) {
                               onToggleHighlight={toggleHighlight}
                               tags={getTagsForMention(m)}
                               aiTags={m.ai_classification_tags || []}
+                              isFreePlan={isFreePlan}
                             />
                           </div>
                         ))}
@@ -1475,6 +1482,7 @@ export default function ModernSocialListeningApp({ onLogout }) {
                   toggleAiTag={toggleAiTagFilter}
                   aiTagOptions={aiTagOptions}
                   clearFilters={clearSidebarFilters}
+                  isFreePlan={isFreePlan}
                 />
               </div>
             </section>

--- a/src/components/AISummary.jsx
+++ b/src/components/AISummary.jsx
@@ -3,8 +3,12 @@
 import { useState } from "react"
 import { ChevronDown, Brain, Lock } from "lucide-react"
 
-export default function ModernAISummary() {
+export default function ModernAISummary({ isFreePlan = true }) {
   const [open, setOpen] = useState(false)
+
+  if (!isFreePlan) {
+    return null
+  }
 
   return (
     <div className="mb-8">

--- a/src/components/MentionCard.jsx
+++ b/src/components/MentionCard.jsx
@@ -23,6 +23,7 @@ import {
   Meh,
   Frown,
   BarChart3,
+  Lock,
 } from "lucide-react"
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip"
 import he from "he"
@@ -40,6 +41,7 @@ export default function ModernMentionCard({
   showDismiss = true,
   tags = [], // precomputed tags
   aiTags = [], // AI classification tags
+  isFreePlan = true,
 }) {
   const icons = {
     twitter: { Icon: FaTwitter, color: "#1DA1F2" },
@@ -94,6 +96,7 @@ export default function ModernMentionCard({
 
   // Get comments sentiment preview
   const getCommentsSentimentPreview = () => {
+    if (isFreePlan) return null
     if (!["youtube", "reddit"].includes(platform) || !topComments.length) return null
 
     const total = Number(mention.comments) || 0
@@ -157,6 +160,23 @@ export default function ModernMentionCard({
 
     const total = Number(mention.comments) || 0
     if (total === 0) return null
+
+    if (isFreePlan) {
+      return (
+        <div className="mt-4 p-4 bg-slate-800/30 rounded-lg border border-slate-700/50">
+          <div className="flex items-center gap-2 mb-4">
+            <BarChart3 className="w-4 h-4 text-slate-400" />
+            <span className="text-sm font-semibold text-white">Análisis de sentimiento</span>
+          </div>
+          <div className="flex flex-col items-center justify-center gap-3 py-6 text-slate-400">
+            <div className="inline-flex items-center justify-center w-10 h-10 bg-slate-700/40 rounded-lg">
+              <Lock className="w-5 h-5 text-slate-400" />
+            </div>
+            <p className="text-sm text-slate-400 text-center">No disponible en versión gratuita</p>
+          </div>
+        </div>
+      )
+    }
 
     const positivePercent = Number(mention.comments_positive_pct) || 0
     const neutralPercent = Number(mention.comments_neutral_pct) || 0
@@ -247,6 +267,70 @@ export default function ModernMentionCard({
               )}
             </div>
           </div>
+        </div>
+      </div>
+    )
+  }
+
+  const renderTopCommentsSection = () => {
+    if (!topComments.length) return null
+
+    if (isFreePlan) {
+      return (
+        <div className="mt-6 pt-4 border-t border-slate-700/50">
+          <div className="flex items-center gap-2 mb-4">
+            <MessageCircle className="w-4 h-4 text-slate-400" />
+            <span className="text-sm font-semibold text-white">Comentarios destacados</span>
+          </div>
+          <div className="flex flex-col items-center justify-center gap-3 py-6 text-slate-400">
+            <div className="inline-flex items-center justify-center w-10 h-10 bg-slate-700/40 rounded-lg">
+              <Lock className="w-5 h-5 text-slate-400" />
+            </div>
+            <p className="text-sm text-slate-400 text-center">No disponible en versión gratuita</p>
+          </div>
+        </div>
+      )
+    }
+
+    return (
+      <div className="mt-6 pt-4 border-t border-slate-700/50">
+        <div className="flex items-center gap-2 mb-4">
+          <MessageCircle className="w-4 h-4 text-slate-400" />
+          <span className="text-sm font-semibold text-white">Comentarios destacados</span>
+        </div>
+
+        <div className="space-y-3">
+          {topComments.map((c, i) => {
+            const CommentIcon = platform === "reddit" ? ArrowBigUp : Heart
+            return (
+              <div
+                key={i}
+                className="p-4 rounded-lg bg-slate-800/40 border border-slate-700/50 flex items-start gap-3 w-full"
+              >
+                <div className="flex-1 min-w-0 w-full">
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <p
+                        className="text-sm text-slate-300 leading-relaxed w-full overflow-hidden text-ellipsis"
+                        style={{
+                          display: "-webkit-box",
+                          WebkitLineClamp: 2,
+                          WebkitBoxOrient: "vertical",
+                        }}
+                      >
+                        {c.comment ? he.decode(c.comment) : "—"}
+                      </p>
+                    </TooltipTrigger>
+                    <TooltipContent>{c.comment ? he.decode(c.comment) : "—"}</TooltipContent>
+                  </Tooltip>
+                </div>
+                <div className="flex items-center gap-1 text-xs font-medium text-slate-400 shrink-0">
+                  <CommentIcon className="w-3 h-3" />
+                  {c.comment_likes ?? 0}
+                </div>
+              </div>
+            )
+          })}
         </div>
       </div>
     )
@@ -495,48 +579,7 @@ export default function ModernMentionCard({
               {expanded && renderSentimentAnalysis()}
 
               {/* Top Comments */}
-              {expanded && topComments.length > 0 && (
-                <div className="mt-6 pt-4 border-t border-slate-700/50">
-                  <div className="flex items-center gap-2 mb-4">
-                    <MessageCircle className="w-4 h-4 text-slate-400" />
-                    <span className="text-sm font-semibold text-white">Comentarios destacados</span>
-                  </div>
-
-                  <div className="space-y-3">
-                    {topComments.map((c, i) => {
-                      const CommentIcon = platform === "reddit" ? ArrowBigUp : Heart
-                      return (
-                        <div
-                          key={i}
-                          className="p-4 rounded-lg bg-slate-800/40 border border-slate-700/50 flex items-start gap-3 w-full"
-                        >
-                          <div className="flex-1 min-w-0 w-full">
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <p
-                                  className="text-sm text-slate-300 leading-relaxed w-full overflow-hidden text-ellipsis"
-                                  style={{
-                                    display: "-webkit-box",
-                                    WebkitLineClamp: 2,
-                                    WebkitBoxOrient: "vertical",
-                                  }}
-                                >
-                                  {c.comment ? he.decode(c.comment) : "—"}
-                                </p>
-                              </TooltipTrigger>
-                              <TooltipContent>{c.comment ? he.decode(c.comment) : "—"}</TooltipContent>
-                            </Tooltip>
-                          </div>
-                          <div className="flex items-center gap-1 text-xs font-medium text-slate-400 shrink-0">
-                            <CommentIcon className="w-3 h-3" />
-                            {c.comment_likes ?? 0}
-                          </div>
-                        </div>
-                      )
-                    })}
-                  </div>
-                </div>
-              )}
+              {expanded && renderTopCommentsSection()}
             </div>
           </div>
         </CardContent>

--- a/src/components/RightSidebar.jsx
+++ b/src/components/RightSidebar.jsx
@@ -21,6 +21,7 @@ export default function RightSidebar({
   toggleAiTag,
   aiTagOptions = [],
   clearFilters,
+  isFreePlan = true,
 }) {
   const handleClearFilters = () => clearFilters()
 
@@ -43,6 +44,19 @@ export default function RightSidebar({
   }
 
   const aiTagClass = "bg-gradient-to-r from-amber-500/10 to-orange-500/10 text-amber-400 border border-amber-500/20"
+
+  const primarySources = [
+    { id: "youtube", label: "YouTube" },
+    { id: "reddit", label: "Reddit" },
+    { id: "twitter", label: "Twitter", requiresUpgrade: true },
+    { id: "tiktok", label: "TikTok", requiresUpgrade: true },
+  ]
+
+  const secondarySources = [
+    { id: "instagram", label: "Instagram", requiresUpgrade: true },
+    { id: "facebook", label: "Facebook", requiresUpgrade: true },
+    { id: "otros", label: "Otros", requiresUpgrade: true },
+  ]
 
   return (
     <TooltipProvider>
@@ -92,77 +106,74 @@ export default function RightSidebar({
 
             <div className="grid grid-cols-2 gap-x-4">
               <div className="space-y-3">
-                {[
-                  { id: "youtube", label: "YouTube" },
-                  { id: "reddit", label: "Reddit" },
-                  { id: "twitter", label: "Twitter", disabled: true },
-                  { id: "tiktok", label: "TikTok", disabled: true },
-                ].map((s) => (
-                  <Tooltip key={s.id}>
-                    <TooltipTrigger asChild>
-                      <label
-                        htmlFor={s.id}
-                        className={cn(
-                          "flex items-center gap-3 p-2 rounded-lg transition-all duration-200 cursor-pointer",
-                          "hover:bg-slate-800/50",
-                          s.disabled && "opacity-50 cursor-not-allowed hover:bg-transparent",
-                        )}
-                      >
-                        <Checkbox
-                          id={s.id}
-                          checked={sources.includes(s.id)}
-                          onCheckedChange={!s.disabled ? () => toggleSource(s.id) : undefined}
-                          disabled={s.disabled}
-                          className="data-[state=checked]:bg-blue-500 data-[state=checked]:border-blue-500"
-                        />
-                        <span className={cn("text-sm", s.disabled ? "text-slate-500" : "text-slate-300")}>
-                          {s.label}
-                        </span>
-                      </label>
-                    </TooltipTrigger>
-                    {s.disabled && (
-                      <TooltipContent className="bg-slate-800/95 backdrop-blur-xl border-slate-700/50 text-slate-300">
-                        No disponible en versión gratuita
-                      </TooltipContent>
-                    )}
-                  </Tooltip>
-                ))}
+                {primarySources.map((s) => {
+                  const disabled = isFreePlan && s.requiresUpgrade
+                  return (
+                    <Tooltip key={s.id}>
+                      <TooltipTrigger asChild>
+                        <label
+                          htmlFor={s.id}
+                          className={cn(
+                            "flex items-center gap-3 p-2 rounded-lg transition-all duration-200 cursor-pointer",
+                            "hover:bg-slate-800/50",
+                            disabled && "opacity-50 cursor-not-allowed hover:bg-transparent",
+                          )}
+                        >
+                          <Checkbox
+                            id={s.id}
+                            checked={sources.includes(s.id)}
+                            onCheckedChange={!disabled ? () => toggleSource(s.id) : undefined}
+                            disabled={disabled}
+                            className="data-[state=checked]:bg-blue-500 data-[state=checked]:border-blue-500"
+                          />
+                          <span className={cn("text-sm", disabled ? "text-slate-500" : "text-slate-300")}>
+                            {s.label}
+                          </span>
+                        </label>
+                      </TooltipTrigger>
+                      {disabled && (
+                        <TooltipContent className="bg-slate-800/95 backdrop-blur-xl border-slate-700/50 text-slate-300">
+                          No disponible en versión gratuita
+                        </TooltipContent>
+                      )}
+                    </Tooltip>
+                  )
+                })}
               </div>
               <div className="space-y-3">
-                {[
-                  { id: "instagram", label: "Instagram", disabled: true },
-                  { id: "facebook", label: "Facebook", disabled: true },
-                  { id: "otros", label: "Otros", disabled: true },
-                ].map((s) => (
-                  <Tooltip key={s.id}>
-                    <TooltipTrigger asChild>
-                      <label
-                        htmlFor={s.id}
-                        className={cn(
-                          "flex items-center gap-3 p-2 rounded-lg transition-all duration-200 cursor-pointer",
-                          "hover:bg-slate-800/50",
-                          s.disabled && "opacity-50 cursor-not-allowed hover:bg-transparent",
-                        )}
-                      >
-                        <Checkbox
-                          id={s.id}
-                          checked={sources.includes(s.id)}
-                          onCheckedChange={!s.disabled ? () => toggleSource(s.id) : undefined}
-                          disabled={s.disabled}
-                          className="data-[state=checked]:bg-blue-500 data-[state=checked]:border-blue-500"
-                        />
-                        <span className={cn("text-sm", s.disabled ? "text-slate-500" : "text-slate-300")}>
-                          {s.label}
-                        </span>
-                      </label>
-                    </TooltipTrigger>
-                    {s.disabled && (
-                      <TooltipContent className="bg-slate-800/95 backdrop-blur-xl border-slate-700/50 text-slate-300">
-                        No disponible en versión gratuita
-                      </TooltipContent>
-                    )}
-                  </Tooltip>
-                ))}
+                {secondarySources.map((s) => {
+                  const disabled = isFreePlan && s.requiresUpgrade
+                  return (
+                    <Tooltip key={s.id}>
+                      <TooltipTrigger asChild>
+                        <label
+                          htmlFor={s.id}
+                          className={cn(
+                            "flex items-center gap-3 p-2 rounded-lg transition-all duration-200 cursor-pointer",
+                            "hover:bg-slate-800/50",
+                            disabled && "opacity-50 cursor-not-allowed hover:bg-transparent",
+                          )}
+                        >
+                          <Checkbox
+                            id={s.id}
+                            checked={sources.includes(s.id)}
+                            onCheckedChange={!disabled ? () => toggleSource(s.id) : undefined}
+                            disabled={disabled}
+                            className="data-[state=checked]:bg-blue-500 data-[state=checked]:border-blue-500"
+                          />
+                          <span className={cn("text-sm", disabled ? "text-slate-500" : "text-slate-300")}>
+                            {s.label}
+                          </span>
+                        </label>
+                      </TooltipTrigger>
+                      {disabled && (
+                        <TooltipContent className="bg-slate-800/95 backdrop-blur-xl border-slate-700/50 text-slate-300">
+                          No disponible en versión gratuita
+                        </TooltipContent>
+                      )}
+                    </Tooltip>
+                  )
+                })}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- track the authenticated user's subscription plan and expose an `isFreePlan` flag to the main UI
- hide the AI summary module for paid plans while keeping the existing locked UI for free accounts
- conditionally disable sidebar sources and gate sentiment analysis plus highlighted comments behind the free-plan lock messaging

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8887e66c8832b9391f2a2b8b3565f