### PR TITLE
Fix profile plan lookup to use correct table

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -593,9 +593,9 @@ export default function ModernSocialListeningApp({ onLogout }) {
     setOriginalAccountName(displayName)
 
     const { data: profileData, error: profileError } = await supabase
-      .from("profile")
+      .from("profiles")
       .select("plan")
-      .eq("user_id", user.id)
+      .eq("id", user.id)
       .maybeSingle()
 
     if (profileError) {


### PR DESCRIPTION
## Summary
- query the Supabase `profiles` table instead of the non-existent `profile` table when loading account plans
- match on the authenticated user's primary key to retrieve the correct subscription plan value

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c88fa95b40832b88edbaedac294bfc