### PR TITLE
Update account fetch to follow auth context

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@
 import { cn } from "@/lib/utils"
 import RightSidebar from "@/components/RightSidebar"
 import { supabase } from "@/lib/supabaseClient"
+import { useAuth } from "@/context/AuthContext"
 import {
   Search,
   CircleUser,
@@ -174,6 +175,7 @@ export default function ModernSocialListeningApp({ onLogout }) {
   const [newKeywordLang, setNewKeywordLang] = useState("")
   const [pendingKeyword, setPendingKeyword] = useState("")
   const navigate = useNavigate()
+  const { user } = useAuth()
   const [onlyFavorites, setOnlyFavorites] = useState(false)
   const [accountEmail, setAccountEmail] = useState("")
   const [accountName, setAccountName] = useState("")
@@ -570,15 +572,6 @@ export default function ModernSocialListeningApp({ onLogout }) {
   }
 
   const fetchAccount = async () => {
-    const {
-      data: { user },
-      error: userError,
-    } = await supabase.auth.getUser()
-
-    if (userError) {
-      console.error("Error fetching authenticated user", userError)
-    }
-
     if (!user) {
       setAccountEmail("")
       setAccountName("")
@@ -654,8 +647,11 @@ export default function ModernSocialListeningApp({ onLogout }) {
 
   useEffect(() => {
     fetchKeywords()
-    fetchAccount()
   }, [])
+
+  useEffect(() => {
+    if (user) fetchAccount()
+  }, [user])
 
   useEffect(() => {
     if (activeTab === "dashboard") {


### PR DESCRIPTION
## Summary
- use the AuthContext hook to access the current user in `App.jsx`
- trigger the account fetch whenever the authenticated user changes and avoid duplicate lookups

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8915d7a3c832b977d804b199f998d