### PR TITLE
Use AI sentiment values for mention badges

### DIFF
--- a/src/components/MentionCard.jsx
+++ b/src/components/MentionCard.jsx
@@ -66,18 +66,38 @@ export default function ModernMentionCard({
   }
 
   // Get mention sentiment (for the main post)
-  // TODO: Replace hardcoded sentiment with real data from mention.sentiment or mention.mention_sentiment
   const getMentionSentiment = () => {
-    // Hardcoded positive sentiment for testing - replace with real data later
-    const mentionSentiment = "positive"
+    const mentionSentimentRaw = mention?.ai_sentiment
+    if (typeof mentionSentimentRaw !== "string") return null
+
+    const mentionSentiment = mentionSentimentRaw.trim().toLowerCase()
+    if (!mentionSentiment) return null
 
     const sentimentConfig = {
-      positive: { icon: Smile, color: "text-green-400", bg: "bg-green-500/10", border: "border-green-500/20" },
-      neutral: { icon: Meh, color: "text-slate-400", bg: "bg-slate-500/10", border: "border-slate-500/20" },
-      negative: { icon: Frown, color: "text-red-400", bg: "bg-red-500/10", border: "border-red-500/20" },
+      positive: {
+        icon: Smile,
+        color: "text-green-400",
+        bg: "bg-green-500/10",
+        border: "border-green-500/20",
+        label: "Positivo",
+      },
+      neutral: {
+        icon: Meh,
+        color: "text-slate-400",
+        bg: "bg-slate-500/10",
+        border: "border-slate-500/20",
+        label: "Neutral",
+      },
+      negative: {
+        icon: Frown,
+        color: "text-red-400",
+        bg: "bg-red-500/10",
+        border: "border-red-500/20",
+        label: "Negativo",
+      },
     }
 
-    const config = sentimentConfig[mentionSentiment.toLowerCase()]
+    const config = sentimentConfig[mentionSentiment]
     if (!config) return null
 
     const SentimentIcon = config.icon
@@ -87,7 +107,7 @@ export default function ModernMentionCard({
         className={`${config.bg} ${config.color} ${config.border} rounded-lg px-3 py-1.5 text-xs font-medium flex items-center gap-1.5`}
       >
         <SentimentIcon className="w-3 h-3" />
-        {mentionSentiment.charAt(0).toUpperCase() + mentionSentiment.slice(1)}
+        {config.label}
       </Badge>
     )
   }


### PR DESCRIPTION
## Summary
- read the `ai_sentiment` field on mentions to render the sentiment badge
- map each sentiment value to the corresponding icon, colors, and a Spanish label while hiding the badge when the value is missing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8b4ab6184832bb4583c22cf65a27a