### PR TITLE
Add plan state to auth context

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,18 +1,49 @@
 import { createContext, useContext, useEffect, useState } from 'react'
 import { supabase } from '@/lib/supabaseClient'
 
-const AuthContext = createContext({ session: null, user: null, loading: true })
+const AuthContext = createContext({
+  session: null,
+  user: null,
+  loading: true,
+  plan: 'free',
+  planLoading: true,
+})
 
 export const AuthProvider = ({ children }) => {
   const [session, setSession] = useState(null)
   const [loading, setLoading] = useState(true)
+  const [plan, setPlan] = useState('free')
+  const [planLoading, setPlanLoading] = useState(true)
 
   useEffect(() => {
+    const fetchUserPlan = async (currentSession) => {
+      if (currentSession?.user) {
+        setPlanLoading(true)
+        const { data, error } = await supabase
+          .from('profiles')
+          .select('plan')
+          .eq('id', currentSession.user.id)
+          .single()
+
+        if (!error && data?.plan) {
+          setPlan(data.plan)
+        } else {
+          setPlan('free')
+        }
+        setPlanLoading(false)
+        return
+      }
+
+      setPlan('free')
+      setPlanLoading(false)
+    }
+
     const initSession = async () => {
       const {
         data: { session },
       } = await supabase.auth.getSession()
       setSession(session)
+      await fetchUserPlan(session)
       setLoading(false)
     }
     initSession()
@@ -21,6 +52,7 @@ export const AuthProvider = ({ children }) => {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, session) => {
       setSession(session)
+      fetchUserPlan(session)
       setLoading(false)
     })
 
@@ -28,7 +60,9 @@ export const AuthProvider = ({ children }) => {
   }, [])
 
   return (
-    <AuthContext.Provider value={{ session, user: session?.user, loading }}>
+    <AuthContext.Provider
+      value={{ session, user: session?.user, loading, plan, planLoading }}
+    >
       {children}
     </AuthContext.Provider>
   )


### PR DESCRIPTION
## Summary
- add plan tracking state to the auth context and query the Supabase profiles table for the active user
- reset the plan when the session ends and expose plan information through the provider

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc5cf2262c832b97e582afb7fb80d1