### PR TITLE
Replace dashboard KPIs with sentiment metrics

### DIFF
--- a/src/components/SentimentKPI.jsx
+++ b/src/components/SentimentKPI.jsx
@@ -14,6 +14,11 @@ export default function SentimentKPI({ sentiment, icon: Icon, color, filters }) 
   const fetchSentimentData = async () => {
     setLoading(true)
     try {
+      if (!filters) {
+        setCurrentPct(0)
+        setWeekOverWeekChange(0)
+        return
+      }
       // Helper functions for date calculations
       const toStartOfDay = (date) => {
         const d = new Date(date)
@@ -77,6 +82,7 @@ export default function SentimentKPI({ sentiment, icon: Icon, color, filters }) 
         p_to: currentPeriodEnd.toISOString(),
         p_platforms: filters.p_platforms,
         p_keywords: filters.p_keywords,
+        p_ai_sentiment: filters.p_ai_sentiment,
         p_ai_classification_tags: filters.p_ai_classification_tags,
       })
 
@@ -88,6 +94,7 @@ export default function SentimentKPI({ sentiment, icon: Icon, color, filters }) 
         p_to: previousPeriodEnd.toISOString(),
         p_platforms: filters.p_platforms,
         p_keywords: filters.p_keywords,
+        p_ai_sentiment: filters.p_ai_sentiment,
         p_ai_classification_tags: filters.p_ai_classification_tags,
       })
 


### PR DESCRIPTION
## Summary
- replace the platform and keyword dashboard KPIs with positive and negative sentiment percentage cards that reuse the SentimentKPI component
- memoize the dashboard filter payload so the sentiment KPIs receive the same filters as the rest of the dashboard
- extend SentimentKPI to handle empty filters and to respect sentiment filters when querying Supabase

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0cae20260832b9a7bbe5ddffcf13f