### PR TITLE
Adjust dashboard filter bar layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1620,11 +1620,11 @@ export default function ModernSocialListeningApp({ onLogout }) {
                 <p className="text-slate-400 mb-6">Revela tendencias y patrones de tus menciones y palabras clave</p>
               </div>
 
-              <div className="relative z-10 flex flex-wrap gap-4 mb-8 p-6 bg-slate-800/30 backdrop-blur-sm border border-slate-700/50 rounded-xl">
-                <div>
+              <div className="relative z-10 flex gap-4 mb-8 p-6 bg-slate-800/30 backdrop-blur-sm border border-slate-700/50 rounded-xl">
+                <div className="min-w-[12rem] w-[12rem]">
                   <p className="text-sm font-medium mb-2 text-slate-300">Palabras clave</p>
                   <MultiSelect
-                    className="w-64"
+                    className="w-full"
                     options={[
                       { value: "all", label: "Todas" },
                       ...activeKeywords.map((k) => ({
@@ -1636,18 +1636,17 @@ export default function ModernSocialListeningApp({ onLogout }) {
                     onChange={setSelectedDashboardKeywords}
                   />
                 </div>
-                <div>
+                <div className="min-w-[12rem] w-[12rem]">
                   <p className="text-sm font-medium mb-2 text-slate-300">Rango de fechas</p>
-                  <div className="flex items-center gap-2">
-                    <DatePickerInput value={startDate} onChange={setStartDate} placeholder="Desde" className="w-40" />
-                    <span className="text-slate-400">a</span>
-                    <DatePickerInput value={endDate} onChange={setEndDate} placeholder="Hasta" className="w-40" />
+                  <div className="flex flex-col gap-2">
+                    <DatePickerInput value={startDate} onChange={setStartDate} placeholder="Desde" className="w-full" />
+                    <DatePickerInput value={endDate} onChange={setEndDate} placeholder="Hasta" className="w-full" />
                   </div>
                 </div>
-                <div>
+                <div className="min-w-[12rem] w-[12rem]">
                   <p className="text-sm font-medium mb-2 text-slate-300">Plataformas</p>
                   <MultiSelect
-                    className="w-40"
+                    className="w-full"
                     options={[
                       { value: "all", label: "Todas" },
                       { value: "youtube", label: "YouTube" },
@@ -1658,20 +1657,20 @@ export default function ModernSocialListeningApp({ onLogout }) {
                     onChange={setSelectedDashboardPlatforms}
                   />
                 </div>
-                <div>
+                <div className="min-w-[12rem] w-[12rem]">
                   <p className="text-sm font-medium mb-2 text-slate-300">Sentimiento</p>
                   <MultiSelect
-                    className="w-40"
+                    className="w-full"
                     options={dashboardSentimentOptions}
                     value={selectedDashboardSentiments}
                     onChange={setSelectedDashboardSentiments}
                     placeholder="Todos"
                   />
                 </div>
-                <div>
+                <div className="min-w-[12rem] w-[12rem]">
                   <p className="text-sm font-medium mb-2 text-slate-300">Clasificación AI</p>
                   <MultiSelect
-                    className="min-w-[12rem]"
+                    className="w-full"
                     options={dashboardAiTagOptions}
                     value={selectedDashboardAiTags}
                     onChange={setSelectedDashboardAiTags}


### PR DESCRIPTION
## Summary
- Keep all dashboard filters aligned in a single row with a unified width.
- Adjust the date range filter layout so the start and end inputs stack vertically.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d15eeed634832babb420c6841d40b9