### PR TITLE
feat: refresh ai filter badges

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1659,7 +1659,12 @@ export default function ModernSocialListeningApp({ onLogout }) {
                   />
                 </div>
                 <div className="min-w-[12rem] w-[12rem]">
-                  <p className="text-sm font-medium mb-2 text-slate-300">Sentimiento</p>
+                  <p className="text-sm font-medium mb-2 text-slate-300 flex items-center gap-2">
+                    Sentimiento
+                    <span className="inline-flex items-center px-3 py-1.5 text-xs font-medium text-purple-300 bg-gradient-to-r from-purple-500/10 to-blue-600/10 border border-purple-500/20 rounded-full">
+                      IA
+                    </span>
+                  </p>
                   <MultiSelect
                     className="w-full"
                     options={dashboardSentimentOptions}
@@ -1669,7 +1674,12 @@ export default function ModernSocialListeningApp({ onLogout }) {
                   />
                 </div>
                 <div className="min-w-[12rem] w-[12rem]">
-                  <p className="text-sm font-medium mb-2 text-slate-300">Clasificación</p>
+                  <p className="text-sm font-medium mb-2 text-slate-300 flex items-center gap-2">
+                    Clasificación
+                    <span className="inline-flex items-center px-3 py-1.5 text-xs font-medium text-purple-300 bg-gradient-to-r from-purple-500/10 to-blue-600/10 border border-purple-500/20 rounded-full">
+                      IA
+                    </span>
+                  </p>
                   <MultiSelect
                     className="w-full"
                     options={dashboardAiTagOptions}

--- a/src/components/RightSidebar.jsx
+++ b/src/components/RightSidebar.jsx
@@ -237,7 +237,7 @@ export default function RightSidebar({
                 <Zap className="w-4 h-4 text-amber-400" />
                 <h4 className="font-medium text-white flex items-center gap-2">
                   Clasificación
-                  <span className="bg-gray-700 text-gray-200 text-[10px] px-2 py-0.5 rounded-full font-semibold shadow-sm">
+                  <span className="inline-flex items-center px-3 py-1.5 text-xs font-medium text-purple-300 bg-gradient-to-r from-purple-500/10 to-blue-600/10 border border-purple-500/20 rounded-full">
                     IA
                   </span>
                 </h4>
@@ -267,7 +267,12 @@ export default function RightSidebar({
             <div className="space-y-4">
               <div className="flex items-center gap-2">
                 <Smile className="w-4 h-4 text-green-400" />
-                <h4 className="font-medium text-white">Sentimiento</h4>
+                <h4 className="font-medium text-white flex items-center gap-2">
+                  Sentimiento
+                  <span className="inline-flex items-center px-3 py-1.5 text-xs font-medium text-purple-300 bg-gradient-to-r from-purple-500/10 to-blue-600/10 border border-purple-500/20 rounded-full">
+                    IA
+                  </span>
+                </h4>
               </div>
               <div className="flex flex-wrap gap-2">
                 {sentimentOptions.map((sentiment) => {


### PR DESCRIPTION
## Summary
- restyle the AI indicator chip with the gradient badge treatment from the summary panel
- reuse the refreshed chip for the Clasificación and Sentimiento sections in the sidebar and dashboard filters

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4c47391c8832bb77bae2d8891d403