### PR TITLE
Rename app branding to Listening Lab

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Social Listening App</title>
+    <title>Listening Lab App</title>
 
     <!-- Fuente Inter desde Google Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1331,7 +1331,7 @@ export default function ModernSocialListeningApp({ onLogout }) {
               <Sparkles className="w-4 h-4 text-white" />
             </div>
             <span className="text-xl font-bold bg-gradient-to-r from-white to-slate-300 bg-clip-text text-transparent">
-              Social Listening
+              Listening Lab
             </span>
           </div>
 

--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -53,7 +53,7 @@ export default function ModernLogin() {
             <h1 className="text-3xl font-semibold tracking-tight bg-gradient-to-r from-white to-slate-300 bg-clip-text text-transparent mb-2">
               Bienvenido de vuelta
             </h1>
-            <p className="text-slate-400">Inicia sesión en tu cuenta de Social Listening</p>
+            <p className="text-slate-400">Inicia sesión en tu cuenta de Listening Lab</p>
           </div>
 
           {/* Login Form */}

--- a/src/OnboardingHome.jsx
+++ b/src/OnboardingHome.jsx
@@ -178,7 +178,7 @@ export default function ModernOnboardingHome() {
                   <Sparkles className="w-8 h-8 text-white" />
                 </div>
                 <h1 className="text-4xl font-semibold tracking-tight bg-gradient-to-r from-white to-slate-300 bg-clip-text text-transparent mb-4">
-                  Bienvenido a Social Listening
+                  Bienvenido a Listening Lab
                 </h1>
                 <p className="text-xl text-slate-400 max-w-lg mx-auto">
                   Descubre qué se dice sobre tu marca en las redes sociales y mantente al día con las conversaciones importantes.

--- a/src/Register.jsx
+++ b/src/Register.jsx
@@ -153,7 +153,7 @@ export default function ModernRegister() {
             <h1 className="text-3xl font-semibold tracking-tight bg-gradient-to-r from-white to-slate-300 bg-clip-text text-transparent mb-2">
               Crear cuenta
             </h1>
-            <p className="text-slate-400">Únete a Social Listening y comienza a monitorear tu marca</p>
+            <p className="text-slate-400">Únete a Listening Lab y comienza a monitorear tu marca</p>
           </div>
 
           {/* Register Form */}


### PR DESCRIPTION
## Summary
- replace all in-app references to "Social Listening" with "Listening Lab" branding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dca435a228832ba8473e3fc5640129